### PR TITLE
TC4-focused Admin Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A mod to add more configuration to Thaumcraft 4. Possibly bugfixes as well.
 * Toggle for champion mobs dropping loot bags
 * Config for max loot bag rarity from champions
 * Whitelist for what dimensions nodes spawn in
+* Admin command to list and trim player research and scans
 
 # Planned Features
 
@@ -25,8 +26,51 @@ A mod to add more configuration to Thaumcraft 4. Possibly bugfixes as well.
 * Up frequency of champion mobs in certain dimensions / biomes?
 * Better tooltip coloring, like for vis discounts?
 
+# `/tmixins` Command
+
+## Sub-commands
+### findResearch
+Usage: `/tmixins findResearch <search text...>`
+
+| Argument | Description |
+|:-:|:-|
+| search text | Only results containing this text will be returned. The text can contain spaces. |
+
+Filters through all research registered with Thaumcraft, returning any whose name or key contains the search text. For ease of searching, results are grouped by category.
+
+### forgetResearch
+Usage: `/tmixins forgetResearch <player> <research key | *> [refund sticky warp]`
+
+| Argument | Description |
+|:-:|:-|
+| player | The player whose completed research will be modified |
+| research key | The key of the root research to remove. Providing `*` instead will remove all of that player's research. Research registered as auto-unlocking is unaffected, though its children might be. |
+| refund sticky warp | If true, an amount of sticky warp equal to that given by completing any forgotten research will be removed. |
+
+Uncompletes some or all of the named player's completed research, allowing it to be completed again. If the research gave permanent warp, an equivalent amount is removed. If refund sticky warp is set, also removes an amount of sticky warp equal to that gained from the removed research.
+
+### forgetScanned
+Usage: `/tmixins forgetScanned <player> <objects | entities | nodes | *>`
+
+| Argument | Description |
+|:-:|:-|
+| player | The player whose completed scans will be modified |
+| objects \| entities \| nodes | Specifies the type of scan to reset. If `*` is provided, all will be reset. |
+
+Clears the appropriate list of scanned things for the player, allowing them to be scanned again. Due to technical limitations (the list of scanned things involves hashes), this is all-or-nothing.
+
+### listResearch
+Usage: `/tmixins listResearch <player> [search text...]`
+
+| Argument | Description |
+|:-:|:-|
+| player | The player whose completed research will be queried |
+| search text | Only completed research whose key contains this text will be returned. The text can contain spaces. |
+
+Returns the named player's list of completed research keys. Can optionally be filtered by search text.
 
 # Credits
 
 * Unicorn Blood - Main Dev
 * GTNH + jss2a98aj - Helping me with random bugs
+* rndmorris - tmixins command

--- a/src/main/java/xyz/uniblood/thaumicmixins/CommonProxy.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/CommonProxy.java
@@ -3,6 +3,7 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import xyz.uniblood.thaumicmixins.commands.CommandThaumicMixins;
 import xyz.uniblood.thaumicmixins.config.ThaumicMixinsConfig;
 
 import java.io.File;
@@ -26,5 +27,7 @@ public class CommonProxy {
     public void postInit(FMLPostInitializationEvent event) {}
 
     // register server commands in this event handler (Remove if not needed)
-    public void serverStarting(FMLServerStartingEvent event) {}
+    public void serverStarting(FMLServerStartingEvent event) {
+        event.registerServerCommand(new CommandThaumicMixins());
+    }
 }

--- a/src/main/java/xyz/uniblood/thaumicmixins/CommonProxy.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/CommonProxy.java
@@ -28,6 +28,8 @@ public class CommonProxy {
 
     // register server commands in this event handler (Remove if not needed)
     public void serverStarting(FMLServerStartingEvent event) {
-        event.registerServerCommand(new CommandThaumicMixins());
+        if (ThaumicMixinsConfig.enableCommand) {
+            event.registerServerCommand(new CommandThaumicMixins());
+        }
     }
 }

--- a/src/main/java/xyz/uniblood/thaumicmixins/ThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/ThaumicMixins.java
@@ -1,5 +1,6 @@
 package xyz.uniblood.thaumicmixins;
 
+import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -21,5 +22,10 @@ public class ThaumicMixins {
     // GameRegistry." (Remove if not needed)
     public void preInit(FMLPreInitializationEvent event) {
         proxy.preInit(event);
+    }
+
+    @Mod.EventHandler
+    public void serverStarting(FMLServerStartingEvent event) {
+        proxy.serverStarting(event);
     }
 }

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -4,6 +4,7 @@ import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetResearch;
+import xyz.uniblood.thaumicmixins.commands.actions.ActionListResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ICommandAction;
 
 import java.util.Arrays;
@@ -17,7 +18,8 @@ public class CommandThaumicMixins extends CommandBase
 
     public CommandThaumicMixins() {
         this.actions = new ICommandAction[] {
-            new ActionForgetResearch(this)
+            new ActionForgetResearch(this),
+            new ActionListResearch(this),
         };
     }
 

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -3,7 +3,7 @@ package xyz.uniblood.thaumicmixins.commands;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
-import xyz.uniblood.thaumicmixins.commands.actions.ActionFindResearchKey;
+import xyz.uniblood.thaumicmixins.commands.actions.ActionFindResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetScanned;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionListResearch;
@@ -23,7 +23,7 @@ public class CommandThaumicMixins extends CommandBase
     public CommandThaumicMixins() {
         final var actions = new LinkedList<ICommandAction>();
         if (ThaumicMixinsConfig.enableFindResearch) {
-            actions.add(new ActionFindResearchKey());
+            actions.add(new ActionFindResearch());
         }
         if (ThaumicMixinsConfig.enableForgetResearch) {
             actions.add(new ActionForgetResearch());

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -3,6 +3,7 @@ package xyz.uniblood.thaumicmixins.commands;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
+import xyz.uniblood.thaumicmixins.commands.actions.ActionFindResearchKey;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetScanned;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionListResearch;
@@ -22,6 +23,7 @@ public class CommandThaumicMixins extends CommandBase
             new ActionForgetResearch(this),
             new ActionListResearch(this),
             new ActionForgetScanned(this),
+            new ActionFindResearchKey(this),
         };
     }
 

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -20,10 +20,10 @@ public class CommandThaumicMixins extends CommandBase
 
     public CommandThaumicMixins() {
         this.actions = new ICommandAction[] {
-            new ActionForgetResearch(this),
-            new ActionListResearch(this),
-            new ActionForgetScanned(this),
-            new ActionFindResearchKey(this),
+            new ActionFindResearchKey(),
+            new ActionForgetResearch(),
+            new ActionForgetScanned(),
+            new ActionListResearch(),
         };
     }
 

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -1,0 +1,81 @@
+package xyz.uniblood.thaumicmixins.commands;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import xyz.uniblood.thaumicmixins.commands.actions.ICommandAction;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CommandThaumicMixins extends CommandBase
+{
+    private static final String USAGE_KEY = "commands.tmixins.usage";
+
+    private final ICommandAction[] actions;
+
+    public CommandThaumicMixins() {
+        this.actions = new ICommandAction[] {};
+    }
+
+    @Override
+    public String getCommandName()
+    {
+        return "tmixins";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel()
+    {
+        return 3; // to-do: load from config?
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender)
+    {
+        return USAGE_KEY;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args)
+    {
+        if (args.length < 1) {
+            throw new WrongUsageException(USAGE_KEY, new Object[0]);
+        }
+        final var action = this.getActionByName(args[0]);
+        if (action == null) {
+            throw new WrongUsageException(USAGE_KEY, new Object[0]);
+        }
+        action.process(sender, args);
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length <= 1) {
+            return getListOfStringsMatchingLastWord(args, Arrays.stream(actions).map(ICommandAction::getName).toArray(String[]::new));
+        }
+        final var action = this.getActionByName(args[0]);
+        if (action == null) {
+            throw new WrongUsageException(USAGE_KEY, new Object[0]);
+        }
+        return action.addTabCompletionOptions(sender, args);
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] args, int index) {
+        if (index == 0 || args.length <= 1) {
+            return false;
+        }
+        final var action = this.getActionByName(args[0]);
+        return action != null && action.isUsernameIndex(args, index);
+    }
+
+    private ICommandAction getActionByName(String name) {
+        for (var action : this.actions) {
+            if (action.getName().equalsIgnoreCase(name)) {
+                return action;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -8,8 +8,10 @@ import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetScanned;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionListResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ICommandAction;
+import xyz.uniblood.thaumicmixins.config.ThaumicMixinsConfig;
 
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 public class CommandThaumicMixins extends CommandBase
@@ -19,12 +21,20 @@ public class CommandThaumicMixins extends CommandBase
     private final ICommandAction[] actions;
 
     public CommandThaumicMixins() {
-        this.actions = new ICommandAction[] {
-            new ActionFindResearchKey(),
-            new ActionForgetResearch(),
-            new ActionForgetScanned(),
-            new ActionListResearch(),
-        };
+        final var actions = new LinkedList<ICommandAction>();
+        if (ThaumicMixinsConfig.enableFindResearch) {
+            actions.add(new ActionFindResearchKey());
+        }
+        if (ThaumicMixinsConfig.enableForgetResearch) {
+            actions.add(new ActionForgetResearch());
+        }
+        if (ThaumicMixinsConfig.enableForgetScanned) {
+            actions.add(new ActionForgetScanned());
+        }
+        if (ThaumicMixinsConfig.enableListResearch) {
+            actions.add(new ActionListResearch());
+        }
+        this.actions = actions.toArray(new ICommandAction[0]);
     }
 
     @Override
@@ -36,7 +46,7 @@ public class CommandThaumicMixins extends CommandBase
     @Override
     public int getRequiredPermissionLevel()
     {
-        return 3; // to-do: load from config?
+        return ThaumicMixinsConfig.commandPermissionLevel;
     }
 
     @Override

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -4,6 +4,7 @@ import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetResearch;
+import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetScanned;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionListResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ICommandAction;
 
@@ -20,6 +21,7 @@ public class CommandThaumicMixins extends CommandBase
         this.actions = new ICommandAction[] {
             new ActionForgetResearch(this),
             new ActionListResearch(this),
+            new ActionForgetScanned(this),
         };
     }
 

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -3,6 +3,7 @@ package xyz.uniblood.thaumicmixins.commands;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
+import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ICommandAction;
 
 import java.util.Arrays;
@@ -15,7 +16,9 @@ public class CommandThaumicMixins extends CommandBase
     private final ICommandAction[] actions;
 
     public CommandThaumicMixins() {
-        this.actions = new ICommandAction[] {};
+        this.actions = new ICommandAction[] {
+            new ActionForgetResearch(this)
+        };
     }
 
     @Override
@@ -40,11 +43,11 @@ public class CommandThaumicMixins extends CommandBase
     public void processCommand(ICommandSender sender, String[] args)
     {
         if (args.length < 1) {
-            throw new WrongUsageException(USAGE_KEY, new Object[0]);
+            throw new WrongUsageException(USAGE_KEY);
         }
         final var action = this.getActionByName(args[0]);
         if (action == null) {
-            throw new WrongUsageException(USAGE_KEY, new Object[0]);
+            throw new WrongUsageException(USAGE_KEY);
         }
         action.process(sender, args);
     }
@@ -56,7 +59,7 @@ public class CommandThaumicMixins extends CommandBase
         }
         final var action = this.getActionByName(args[0]);
         if (action == null) {
-            throw new WrongUsageException(USAGE_KEY, new Object[0]);
+            throw new WrongUsageException(USAGE_KEY);
         }
         return action.addTabCompletionOptions(sender, args);
     }

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionFindResearch.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionFindResearch.java
@@ -6,18 +6,18 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import thaumcraft.api.research.ResearchCategories;
 
-public class ActionFindResearchKey extends CommandAction
+public class ActionFindResearch extends CommandAction
 {
-    public static final String USAGE_KEY = "commands.tmixins.findresearchkey.usage";
-    public static final String CATEGORY_HEADER_KEY = "commands.tmixins.findresearchkey.category";
-    public static final String NONE_FOUND_KEY = "commands.tmixins.findresearchkey.nonefound";
+    public static final String USAGE_KEY = "commands.tmixins.findresearch.usage";
+    public static final String CATEGORY_HEADER_KEY = "commands.tmixins.findresearch.category";
+    public static final String NONE_FOUND_KEY = "commands.tmixins.findresearch.nonefound";
 
     public static final int ARG_INDEX_SEARCH_TEXT_START = 1;
 
     @Override
     public String getName()
     {
-        return "findResearchKey";
+        return "findResearch";
     }
 
     @Override
@@ -42,7 +42,7 @@ public class ActionFindResearchKey extends CommandAction
             var research = category.research
                 .values()
                 .stream()
-                .filter(r -> r.getName().toUpperCase().contains(searchTextUpper));
+                .filter(r -> r.getName().toUpperCase().contains(searchTextUpper) || r.key.toUpperCase().contains(searchTextUpper));
             final var iterator = research.iterator();
             if (!iterator.hasNext()) {
                 continue;

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionFindResearchKey.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionFindResearchKey.java
@@ -1,6 +1,5 @@
 package xyz.uniblood.thaumicmixins.commands.actions;
 
-import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.util.ChatComponentText;
@@ -14,10 +13,6 @@ public class ActionFindResearchKey extends CommandAction
     public static final String NONE_FOUND_KEY = "commands.tmixins.findresearchkey.nonefound";
 
     public static final int ARG_INDEX_SEARCH_TEXT_START = 1;
-
-    public ActionFindResearchKey(CommandBase owningCommand) {
-        super(owningCommand);
-    }
 
     @Override
     public String getName()
@@ -36,7 +31,7 @@ public class ActionFindResearchKey extends CommandAction
             throw new WrongUsageException(USAGE_KEY);
         }
         final var searchText = argSearchText(args);
-        final var searchTextUpper = searchText != null ? searchText.toUpperCase() : null;
+        final var searchTextUpper = searchText != null ? searchText.toUpperCase() : "";
         final var listMessageContents = new StringBuilder();
 
         var foundAny = false;
@@ -46,10 +41,8 @@ public class ActionFindResearchKey extends CommandAction
             final var category = categories.get(categoryKey);
             var research = category.research
                 .values()
-                .stream();
-            if (searchTextUpper != null) {
-                research = research.filter(r -> r.getName().toUpperCase().contains(searchTextUpper));
-            }
+                .stream()
+                .filter(r -> r.getName().toUpperCase().contains(searchTextUpper));
             final var iterator = research.iterator();
             if (!iterator.hasNext()) {
                 continue;

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionFindResearchKey.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionFindResearchKey.java
@@ -1,0 +1,89 @@
+package xyz.uniblood.thaumicmixins.commands.actions;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+import thaumcraft.api.research.ResearchCategories;
+
+public class ActionFindResearchKey extends CommandAction
+{
+    public static final String USAGE_KEY = "commands.tmixins.findresearchkey.usage";
+    public static final String CATEGORY_HEADER_KEY = "commands.tmixins.findresearchkey.category";
+    public static final String NONE_FOUND_KEY = "commands.tmixins.findresearchkey.nonefound";
+
+    public static final int ARG_INDEX_SEARCH_TEXT_START = 1;
+
+    public ActionFindResearchKey(CommandBase owningCommand) {
+        super(owningCommand);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "findResearchKey";
+    }
+
+    @Override
+    public String getUsage() {
+        return USAGE_KEY;
+    }
+
+    @Override
+    public void process(ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            throw new WrongUsageException(USAGE_KEY);
+        }
+        final var searchText = argSearchText(args);
+        final var searchTextUpper = searchText != null ? searchText.toUpperCase() : null;
+        final var listMessageContents = new StringBuilder();
+
+        var foundAny = false;
+
+        final var categories = ResearchCategories.researchCategories;
+        for (var categoryKey : categories.keySet()) {
+            final var category = categories.get(categoryKey);
+            var research = category.research
+                .values()
+                .stream();
+            if (searchTextUpper != null) {
+                research = research.filter(r -> r.getName().toUpperCase().contains(searchTextUpper));
+            }
+            final var iterator = research.iterator();
+            if (!iterator.hasNext()) {
+                continue;
+            }
+            foundAny = true;
+            listMessageContents.delete(0, listMessageContents.length());
+            while (iterator.hasNext()) {
+                final var item = iterator.next();
+                listMessageContents.append('\'').append(item.getName()).append("' (").append(item.key).append(')');
+
+                if (iterator.hasNext()) {
+                    listMessageContents.append(", ");
+                }
+            }
+            sendColoredMessage(EnumChatFormatting.DARK_PURPLE, sender, CATEGORY_HEADER_KEY, ResearchCategories.getCategoryName(categoryKey));
+            sender.addChatMessage(new ChatComponentText(listMessageContents.toString()));
+        }
+
+        if (!foundAny) {
+            sendErrorMessage(sender, NONE_FOUND_KEY, searchText);
+        }
+    }
+
+    private static String argSearchText(String[] args) {
+        if (args == null || args.length < ARG_INDEX_SEARCH_TEXT_START + 1) {
+            return null;
+        }
+        final var stringBuilder = new StringBuilder();
+        for (var index = ARG_INDEX_SEARCH_TEXT_START; index < args.length; ++index) {
+            stringBuilder.append(args[index]);
+            if (index < args.length - 1) {
+                stringBuilder.append(' ');
+            }
+        }
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetResearch.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetResearch.java
@@ -18,6 +18,7 @@ import thaumcraft.common.lib.research.ResearchManager;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,10 +32,15 @@ public class ActionForgetResearch extends CommandAction
     public static final String MISSING_RESEARCH_KEY = "commands.tmixins.forgetresearch.doesnotknow";
     public static final String SUCCESS_KEY = "commands.tmixins.forgetresearch.success";
     public static final String NOTIFY_KEY = "commands.tmixins.forgetresearch.notify";
+    public static final String SUCCESS_ALL_KEY = "commands.tmixins.forgetresearch.successall";
+    public static final String NOTIFY_ALL_KEY = "commands.tmixins.forgetresearch.notifyall";
 
     public static final int ARG_INDEX_TARGET_PLAYER = 1;
     public static final int ARG_INDEX_RESEARCH_KEY = 2;
     public static final int ARG_INDEX_REFUND_STICKY = 3;
+    public static final String ALL_RESEARCH = "*";
+    public static final String TRUE = "true";
+    public static final String FALSE = "false";
 
     public ActionForgetResearch(CommandBase owningCommand)
     {
@@ -59,12 +65,20 @@ public class ActionForgetResearch extends CommandAction
             throw new WrongUsageException(USAGE_KEY);
         }
         final var targetPlayer = argTargetPlayer(sender, args);
+        final var allResearch = ALL_RESEARCH.equals(args[ARG_INDEX_RESEARCH_KEY]);
+        final var refundStickyWarp = argRefundStickyWarp(sender, args);
+
+        if (allResearch) {
+            forgetAllResearch(sender, targetPlayer, refundStickyWarp);
+            return;
+        }
+
         final var targetResearch = argTargetResearch(args);
         if (targetResearch == null) {
             sendErrorMessage(sender, NONEXISTENT_RESEARCH_KEY, args[ARG_INDEX_RESEARCH_KEY]);
             return;
         }
-        final var refundStickyWarp = argRefundStickyWarp(sender, args);
+
         forgetResearchAndRelated(sender, targetPlayer, targetResearch, refundStickyWarp);
     }
 
@@ -84,13 +98,15 @@ public class ActionForgetResearch extends CommandAction
             if (player == null) {
                 return Collections.emptyList();
             }
-            return CommandBase.getListOfStringsFromIterableMatchingLastWord(
-                args,
-                new ArrayList<>(getResearchKeys(player.getCommandSenderName()))
-            );
+            final var options = new ArrayList<>(Thaumcraft.proxy
+                .getPlayerKnowledge()
+                .researchCompleted
+                .get(player.getCommandSenderName()));
+            options.add(ALL_RESEARCH);
+            return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, options);
         }
         if (args.length == ARG_INDEX_REFUND_STICKY + 1) {
-            return CommandBase.getListOfStringsMatchingLastWord(args, "true", "false");
+            return CommandBase.getListOfStringsMatchingLastWord(args, TRUE, FALSE);
         }
         return Collections.emptyList();
     }
@@ -116,13 +132,6 @@ public class ActionForgetResearch extends CommandAction
         return CommandBase.parseBoolean(sender, args[ARG_INDEX_REFUND_STICKY]);
     }
 
-    private List<String> getResearchKeys(String playerName) {
-        return Thaumcraft.proxy
-            .getPlayerKnowledge()
-            .researchCompleted
-            .get(playerName);
-    }
-
     private void forgetResearchAndRelated(ICommandSender sender, EntityPlayerMP targetPlayer, ResearchItem rootResearch, boolean refundStickyWarp) {
         final var playerName = targetPlayer.getCommandSenderName();
         final var researchName = rootResearch.getName();
@@ -131,8 +140,36 @@ public class ActionForgetResearch extends CommandAction
             return;
         }
 
+        final var queue = new LinkedList<String>();
+        queue.add(rootResearch.key);
+        forgetFromQueue(targetPlayer, refundStickyWarp, queue);
+
+        sendSuccessMessage(sender, SUCCESS_KEY, playerName, researchName);
+        sendColoredMessage(EnumChatFormatting.DARK_PURPLE, targetPlayer, NOTIFY_KEY, sender.getCommandSenderName(), researchName);
+    }
+
+    // Yes, this exists in the base TC4 command. The base TC4 command doesn't have proper autocompletion right now. This does.
+    private void forgetAllResearch(ICommandSender sender, EntityPlayerMP targetPlayer, boolean refundStickyWarp) {
+        final var playerName = targetPlayer.getCommandSenderName();
+        final var allPlayerResearch = new LinkedList<>(Thaumcraft.proxy.getPlayerKnowledge().researchCompleted.get(playerName));
+        forgetFromQueue(targetPlayer, refundStickyWarp, allPlayerResearch);
+
+        sendSuccessMessage(sender, SUCCESS_ALL_KEY, playerName);
+        sendColoredMessage(EnumChatFormatting.DARK_PURPLE, targetPlayer, NOTIFY_ALL_KEY, sender.getCommandSenderName());
+    }
+
+    private void forgetFromQueue(EntityPlayerMP targetPlayer, boolean refundStickyWarp, Deque<String> forgetQueue) {
+        final var playerName = targetPlayer.getCommandSenderName();
+
         // This should always be a reference to the exact list TC4 uses in-memory
-        final var knownResearchKeys = getResearchKeys(playerName);
+        final var knownResearchKeys = Thaumcraft.proxy
+            .getPlayerKnowledge()
+            .researchCompleted
+            .get(playerName);
+
+        if (knownResearchKeys == null) {
+            return;
+        }
 
         // Used for looking up sibling and descendant research
         final var knownResearchData = knownResearchKeys.stream()
@@ -141,11 +178,7 @@ public class ActionForgetResearch extends CommandAction
             .filter(Objects::nonNull)
             .collect(Collectors.toMap(r -> r.key, r -> r));
 
-        final var forgetQueue = new LinkedList<String>();
-        final var hasBeenQueued = new HashSet<String>();
-
-        forgetQueue.add(rootResearch.key);
-        hasBeenQueued.add(rootResearch.key);
+        final var hasBeenQueued = new HashSet<>(forgetQueue);
 
         var permanentWarpRefund = 0;
         var stickyWarpRefund = 0;
@@ -187,9 +220,6 @@ public class ActionForgetResearch extends CommandAction
             adjustStickyWarp(targetPlayer, stickyWarpRefund);
         }
         ResearchManager.scheduleSave(targetPlayer);
-
-        sendSuccessMessage(sender, SUCCESS_KEY, playerName, researchName);
-        sendColoredMessage(EnumChatFormatting.DARK_PURPLE, targetPlayer, NOTIFY_KEY, sender.getCommandSenderName(), researchName);
     }
 
     private static boolean isRelated(ResearchItem item, String query) {

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetResearch.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetResearch.java
@@ -1,0 +1,216 @@
+package xyz.uniblood.thaumicmixins.commands.actions;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.EnumChatFormatting;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.config.Config;
+import thaumcraft.common.lib.network.PacketHandler;
+import thaumcraft.common.lib.network.playerdata.PacketSyncWarp;
+import thaumcraft.common.lib.research.ResearchManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ActionForgetResearch extends CommandAction
+{
+    public static final String USAGE_KEY = "commands.tmixins.forgetresearch.usage";
+    public static final String NONEXISTENT_RESEARCH_KEY = "commands.tmixins.forgetresearch.noresearch";
+    public static final String MISSING_RESEARCH_KEY = "commands.tmixins.forgetresearch.doesnotknow";
+    public static final String SUCCESS_KEY = "commands.tmixins.forgetresearch.success";
+    public static final String NOTIFY_KEY = "commands.tmixins.forgetresearch.notify";
+
+    public static final int ARG_INDEX_TARGET_PLAYER = 1;
+    public static final int ARG_INDEX_RESEARCH_KEY = 2;
+    public static final int ARG_INDEX_REFUND_STICKY = 3;
+
+    public ActionForgetResearch(CommandBase owningCommand)
+    {
+        super(owningCommand);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "forgetResearch";
+    }
+
+    @Override
+    public String getUsage()
+    {
+        return USAGE_KEY;
+    }
+
+    @Override
+    public void process(ICommandSender sender, String[] args) {
+        if (args.length < 3) {
+            throw new WrongUsageException(USAGE_KEY);
+        }
+        final var targetPlayer = argTargetPlayer(sender, args);
+        final var targetResearch = argTargetResearch(args);
+        if (targetResearch == null) {
+            sendErrorMessage(sender, NONEXISTENT_RESEARCH_KEY, args[ARG_INDEX_RESEARCH_KEY]);
+            return;
+        }
+        final var refundStickyWarp = argRefundStickyWarp(sender, args);
+        forgetResearchAndRelated(sender, targetPlayer, targetResearch, refundStickyWarp);
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] args, int index)
+    {
+        return index == 1;
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == ARG_INDEX_TARGET_PLAYER + 1) {
+            return CommandBase.getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
+        }
+        if (args.length == ARG_INDEX_RESEARCH_KEY + 1) {
+            final var player = argTargetPlayer(sender, args);
+            if (player == null) {
+                return Collections.emptyList();
+            }
+            return CommandBase.getListOfStringsFromIterableMatchingLastWord(
+                args,
+                new ArrayList<>(getResearchKeys(player.getCommandSenderName()))
+            );
+        }
+        if (args.length == ARG_INDEX_REFUND_STICKY + 1) {
+            return CommandBase.getListOfStringsMatchingLastWord(args, "true", "false");
+        }
+        return Collections.emptyList();
+    }
+
+    private static EntityPlayerMP argTargetPlayer(ICommandSender sender, String[] args) {
+        if (args == null || args.length < ARG_INDEX_TARGET_PLAYER + 1) {
+            return null;
+        }
+        return CommandBase.getPlayer(sender, args[ARG_INDEX_TARGET_PLAYER]);
+    }
+
+    private static ResearchItem argTargetResearch(String[] args) {
+        if (args == null || args.length < ARG_INDEX_RESEARCH_KEY + 1) {
+            return null;
+        }
+        return ResearchCategories.getResearch(args[ARG_INDEX_RESEARCH_KEY]);
+    }
+
+    private static boolean argRefundStickyWarp(ICommandSender sender, String[] args) {
+        if (args == null || args.length < ARG_INDEX_REFUND_STICKY + 1) {
+            return false;
+        }
+        return CommandBase.parseBoolean(sender, args[ARG_INDEX_REFUND_STICKY]);
+    }
+
+    private List<String> getResearchKeys(String playerName) {
+        return Thaumcraft.proxy
+            .getPlayerKnowledge()
+            .researchCompleted
+            .get(playerName);
+    }
+
+    private void forgetResearchAndRelated(ICommandSender sender, EntityPlayerMP targetPlayer, ResearchItem rootResearch, boolean refundStickyWarp) {
+        final var playerName = targetPlayer.getCommandSenderName();
+        final var researchName = rootResearch.getName();
+        if (!ResearchManager.isResearchComplete(playerName, rootResearch.key)) {
+            sendErrorMessage(sender, MISSING_RESEARCH_KEY, playerName, researchName);
+            return;
+        }
+
+        // This should always be a reference to the exact list TC4 uses in-memory
+        final var knownResearchKeys = getResearchKeys(playerName);
+
+        // Used for looking up sibling and descendant research
+        final var knownResearchData = knownResearchKeys.stream()
+            .filter(Objects::nonNull)
+            .map(ResearchCategories::getResearch)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toMap(r -> r.key, r -> r));
+
+        final var forgetQueue = new LinkedList<String>();
+        final var hasBeenQueued = new HashSet<String>();
+
+        forgetQueue.add(rootResearch.key);
+        hasBeenQueued.add(rootResearch.key);
+
+        var permanentWarpRefund = 0;
+        var stickyWarpRefund = 0;
+
+        while (!forgetQueue.isEmpty()) {
+            final var currentKey = forgetQueue.poll();
+            final var researchItem = knownResearchData.get(currentKey);
+
+            // auto-unlocked research is *always* available,
+            // even if it has parents, so we skip those
+            if (!researchItem.isAutoUnlock()) {
+                final var index = knownResearchKeys.indexOf(currentKey);
+                if (index >= 0) {
+                    knownResearchKeys.remove(index);
+                }
+
+                // see ResearchManager.completeResearch(...)
+                final var totalWarp = ThaumcraftApi.getWarp(currentKey);
+                if(totalWarp > 0 && !Config.wuss && !targetPlayer.worldObj.isRemote) {
+                    final var stickyWarp = totalWarp / 2;
+                    final var permanentWarp = totalWarp - stickyWarp;
+                    permanentWarpRefund += permanentWarp;
+                    stickyWarpRefund += stickyWarp;
+                }
+            }
+
+            // queue up any related research that needs to be forgotten
+            knownResearchData.values()
+                .stream()
+                .filter(item -> !hasBeenQueued.contains(item.key) && isRelated(item, currentKey))
+                .forEach(item -> {
+                    forgetQueue.add(item.key);
+                    hasBeenQueued.add(item.key);
+                });
+        }
+
+        adjustPermanentWarp(targetPlayer, permanentWarpRefund);
+        if (refundStickyWarp) {
+            adjustStickyWarp(targetPlayer, stickyWarpRefund);
+        }
+        ResearchManager.scheduleSave(targetPlayer);
+
+        sendSuccessMessage(sender, SUCCESS_KEY, playerName, researchName);
+        sendColoredMessage(EnumChatFormatting.DARK_PURPLE, targetPlayer, NOTIFY_KEY, sender.getCommandSenderName(), researchName);
+    }
+
+    private static boolean isRelated(ResearchItem item, String query) {
+        return checkArray(item.siblings, query) || checkArray(item.parents, query) || checkArray(item.parentsHidden, query);
+    }
+
+    private static boolean checkArray(String[] arr, String query) {
+        return arr != null && arr.length > 0 && Arrays.asList(arr).contains(query);
+    }
+
+    private void adjustPermanentWarp(EntityPlayerMP player, int amount) {
+        final var name = player.getCommandSenderName();
+        final var warp = Thaumcraft.proxy.playerKnowledge.getWarpPerm(name);
+        Thaumcraft.proxy.playerKnowledge.setWarpPerm(name, Integer.max(warp - amount, 0));
+        PacketHandler.INSTANCE.sendTo(new PacketSyncWarp(player, (byte)0), player);
+    }
+
+    private void adjustStickyWarp(EntityPlayerMP player, int amount) {
+        final var name = player.getCommandSenderName();
+        final var warp = Thaumcraft.proxy.playerKnowledge.getWarpSticky(name);
+        Thaumcraft.proxy.playerKnowledge.setWarpSticky(name, Integer.max(warp - amount, 0));
+        PacketHandler.INSTANCE.sendTo(new PacketSyncWarp(player, (byte)1), player);
+    }
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetResearch.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetResearch.java
@@ -42,11 +42,6 @@ public class ActionForgetResearch extends CommandAction
     public static final String TRUE = "true";
     public static final String FALSE = "false";
 
-    public ActionForgetResearch(CommandBase owningCommand)
-    {
-        super(owningCommand);
-    }
-
     @Override
     public String getName()
     {

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetScanned.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetScanned.java
@@ -1,0 +1,156 @@
+package xyz.uniblood.thaumicmixins.commands.actions;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.EnumChatFormatting;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.lib.research.ResearchManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ActionForgetScanned extends CommandAction
+{
+    public static final String USAGE_KEY = "commands.tmixins.forgetscanned.usage";
+    public static final String INVALID_RESET_TYPE_KEY = "commands.tmixins.forgetscanned.invalidtype";
+    public static final String SUCCESS_KEY = "commands.tmixins.forgetscanned.success";
+    public static final String NOTIFY_KEY = "commands.tmixins.forgetscanned.notify";
+    public static final String SUCCESS_ALL_KEY = "commands.tmixins.forgetscanned.successall";
+    public static final String NOTIFY_ALL_KEY = "commands.tmixins.forgetscanned.notifyall";
+
+    public static final int ARG_INDEX_TARGET_PLAYER = 1;
+    public static final int ARG_INDEX_TARGET_TYPE = 2;
+
+    public ActionForgetScanned(CommandBase owningCommand) {
+        super(owningCommand);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "forgetScanned";
+    }
+
+    @Override
+    public String getUsage()
+    {
+        return USAGE_KEY;
+    }
+
+    @Override
+    public void process(ICommandSender sender, String[] args)
+    {
+        if (args.length < 3) {
+            throw new WrongUsageException(USAGE_KEY);
+        }
+        final var player = argTargetPlayer(sender, args);
+        final var resetType = argResetType(args);
+        if (resetType == null) {
+            sendErrorMessage(sender, INVALID_RESET_TYPE_KEY, args[ARG_INDEX_TARGET_TYPE]);
+            return;
+        }
+
+        final var playerName = player.getCommandSenderName();
+        final var playerKnowledge = Thaumcraft.proxy.getPlayerKnowledge();
+        final var resetCount = switch (resetType) {
+            case Objects -> forgetScanned(player, playerKnowledge.objectsScanned);
+            case Entities -> forgetScanned(player, playerKnowledge.entitiesScanned);
+            case Phenomena -> forgetScanned(player, playerKnowledge.phenomenaScanned);
+            case All -> forgetScanned(player, playerKnowledge.objectsScanned, playerKnowledge.entitiesScanned, playerKnowledge.phenomenaScanned);
+        };
+
+        if (resetCount > 0) {
+            ResearchManager.scheduleSave(player);
+        }
+
+        final var senderName = sender.getCommandSenderName();
+        if (resetType == ResetType.All) {
+            sendSuccessMessage(sender, SUCCESS_ALL_KEY, playerName, resetCount);
+            sendColoredMessage(EnumChatFormatting.DARK_PURPLE, player, NOTIFY_ALL_KEY, senderName);
+            return;
+        }
+        sendSuccessMessage(sender, SUCCESS_KEY, playerName, resetCount, resetType.toString());
+        sendColoredMessage(EnumChatFormatting.DARK_PURPLE, player, NOTIFY_KEY, senderName, resetType.toString());
+    }
+
+    @SafeVarargs
+    private int forgetScanned(EntityPlayerMP player, Map<String, ArrayList<String>>... resetMaps) {
+        final var playerName = player.getCommandSenderName();
+        var forgotten = 0;
+        for (var map : resetMaps) {
+            if (map == null) {
+                continue;
+            }
+            final var scanList = map.get(playerName);
+            if (scanList == null) {
+                continue;
+            }
+            forgotten += scanList.size();
+            scanList.clear();
+        }
+        return forgotten;
+    }
+
+    private static EntityPlayerMP argTargetPlayer(ICommandSender sender, String[] args) {
+        if (args == null || args.length < ARG_INDEX_TARGET_PLAYER + 1) {
+            return null;
+        }
+        return CommandBase.getPlayer(sender, args[ARG_INDEX_TARGET_PLAYER]);
+    }
+
+    private static ResetType argResetType(String[] args) {
+        if (args == null || args.length < ARG_INDEX_TARGET_TYPE + 1) {
+            return null;
+        }
+        return ResetType.fromString(args[ARG_INDEX_TARGET_TYPE]);
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] args, int index) {
+        return index == ARG_INDEX_TARGET_PLAYER;
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == ARG_INDEX_TARGET_PLAYER + 1) {
+            return CommandBase.getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
+        }
+        if (args.length == ARG_INDEX_TARGET_TYPE + 1) {
+            final var options = Arrays.stream(ResetType.values()).map(ResetType::toString).toArray(String[]::new);
+            return CommandBase.getListOfStringsMatchingLastWord(args, options);
+        }
+        return Collections.emptyList();
+    }
+
+    private enum ResetType {
+        Objects,
+        Entities,
+        Phenomena,
+        All;
+
+        @Override
+        public String toString() {
+            return switch (this) {
+                case Objects -> "objects";
+                case Entities -> "entities";
+                case Phenomena -> "nodes";
+                case All -> "*";
+            };
+        }
+
+        public static ResetType fromString(String string) {
+            for (var val : ResetType.values()) {
+                if (val.toString().equalsIgnoreCase(string)) {
+                    return val;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetScanned.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionForgetScanned.java
@@ -27,10 +27,6 @@ public class ActionForgetScanned extends CommandAction
     public static final int ARG_INDEX_TARGET_PLAYER = 1;
     public static final int ARG_INDEX_TARGET_TYPE = 2;
 
-    public ActionForgetScanned(CommandBase owningCommand) {
-        super(owningCommand);
-    }
-
     @Override
     public String getName()
     {

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionListResearch.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionListResearch.java
@@ -1,0 +1,102 @@
+package xyz.uniblood.thaumicmixins.commands.actions;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+import thaumcraft.common.Thaumcraft;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class ActionListResearch extends CommandAction
+{
+    public static final String USAGE_KEY = "commands.tmixins.listresearch.usage";
+
+    public static final int ARG_INDEX_TARGET_PLAYER = 1;
+    public static final int ARG_INDEX_SEARCH_TEXT_START = 2;
+
+    public ActionListResearch(CommandBase owningCommand) {
+        super(owningCommand);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "listResearch";
+    }
+
+    @Override
+    public String getUsage() {
+        return USAGE_KEY;
+    }
+
+    @Override
+    public void process(ICommandSender sender, String[] args) {
+        if (args.length < 2) {
+            throw new WrongUsageException(USAGE_KEY);
+        }
+        final var targetPlayer = argTargetPlayer(sender, args);
+        final var searchText = argSearchText(args);
+
+        var researchList = Optional
+            .ofNullable((List<String>) Thaumcraft.proxy.getPlayerKnowledge().researchCompleted.get(targetPlayer.getCommandSenderName()))
+            .orElse(Collections.emptyList())
+            .stream();
+        if (searchText != null) {
+            final var search = searchText.toUpperCase();
+            researchList = researchList.filter(key -> key.toUpperCase().contains(search));
+        }
+
+        final var messageContents = new StringBuilder();
+        final var iterator = researchList.iterator();
+        while (iterator.hasNext()) {
+            final var key = iterator.next();
+            messageContents.append(key);
+            if (iterator.hasNext()) {
+                messageContents.append(", ");
+            }
+        }
+        final var message = new ChatComponentText(messageContents.toString());
+        message.getChatStyle().setColor(EnumChatFormatting.DARK_PURPLE);
+        sender.addChatMessage(message);
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] args, int index) {
+        return index == ARG_INDEX_TARGET_PLAYER;
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length == ARG_INDEX_TARGET_PLAYER + 1) {
+            return CommandBase.getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
+        }
+        return Collections.emptyList();
+    }
+
+    private static EntityPlayerMP argTargetPlayer(ICommandSender sender, String[] args) {
+        if (args == null || args.length < ARG_INDEX_TARGET_PLAYER + 1) {
+            return null;
+        }
+        return CommandBase.getPlayer(sender, args[ARG_INDEX_TARGET_PLAYER]);
+    }
+    private static String argSearchText(String[] args) {
+        if (args == null || args.length < ARG_INDEX_SEARCH_TEXT_START + 1) {
+            return null;
+        }
+        final var stringBuilder = new StringBuilder();
+        for (var index = ARG_INDEX_SEARCH_TEXT_START; index < args.length; ++index) {
+            stringBuilder.append(args[index]);
+            if (index < args.length - 1) {
+                stringBuilder.append(' ');
+            }
+        }
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionListResearch.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionListResearch.java
@@ -86,6 +86,7 @@ public class ActionListResearch extends CommandAction
         }
         return CommandBase.getPlayer(sender, args[ARG_INDEX_TARGET_PLAYER]);
     }
+    
     private static String argSearchText(String[] args) {
         if (args == null || args.length < ARG_INDEX_SEARCH_TEXT_START + 1) {
             return null;

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionListResearch.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionListResearch.java
@@ -9,7 +9,6 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import thaumcraft.common.Thaumcraft;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -20,10 +19,6 @@ public class ActionListResearch extends CommandAction
 
     public static final int ARG_INDEX_TARGET_PLAYER = 1;
     public static final int ARG_INDEX_SEARCH_TEXT_START = 2;
-
-    public ActionListResearch(CommandBase owningCommand) {
-        super(owningCommand);
-    }
 
     @Override
     public String getName()
@@ -86,7 +81,7 @@ public class ActionListResearch extends CommandAction
         }
         return CommandBase.getPlayer(sender, args[ARG_INDEX_TARGET_PLAYER]);
     }
-    
+
     private static String argSearchText(String[] args) {
         if (args == null || args.length < ARG_INDEX_SEARCH_TEXT_START + 1) {
             return null;

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/CommandAction.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/CommandAction.java
@@ -1,0 +1,34 @@
+package xyz.uniblood.thaumicmixins.commands.actions;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class CommandAction implements ICommandAction
+{
+    /**
+     * The command this action belongs to.
+     */
+    protected final CommandBase owningCommand;
+
+    /**
+     * @param owningCommand The command this action belongs to.
+     */
+    public CommandAction(CommandBase owningCommand) {
+        this.owningCommand = owningCommand;
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args)
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isUsernameIndex(String[] args, int index)
+    {
+        return false;
+    }
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/CommandAction.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/CommandAction.java
@@ -1,6 +1,5 @@
 package xyz.uniblood.thaumicmixins.commands.actions;
 
-import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
@@ -10,18 +9,6 @@ import java.util.List;
 
 public abstract class CommandAction implements ICommandAction
 {
-    /**
-     * The command this action belongs to.
-     */
-    protected final CommandBase owningCommand;
-
-    /**
-     * @param owningCommand The command this action belongs to.
-     */
-    public CommandAction(CommandBase owningCommand) {
-        this.owningCommand = owningCommand;
-    }
-
     @Override
     public List<String> addTabCompletionOptions(ICommandSender sender, String[] args)
     {

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/CommandAction.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/CommandAction.java
@@ -2,6 +2,8 @@ package xyz.uniblood.thaumicmixins.commands.actions;
 
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
 
 import java.util.Collections;
 import java.util.List;
@@ -30,5 +32,19 @@ public abstract class CommandAction implements ICommandAction
     public boolean isUsernameIndex(String[] args, int index)
     {
         return false;
+    }
+
+    protected static void sendErrorMessage(ICommandSender toPlayer, String translationKey, Object... args) {
+        sendColoredMessage(EnumChatFormatting.RED, toPlayer, translationKey, args);
+    }
+
+    protected static void sendSuccessMessage(ICommandSender toPlayer, String translationKey, Object... args) {
+        sendColoredMessage(EnumChatFormatting.GREEN, toPlayer, translationKey, args);
+    }
+
+    protected static void sendColoredMessage(EnumChatFormatting color, ICommandSender toPlayer, String translationKey, Object... args) {
+        final var message = new ChatComponentTranslation(translationKey, args);
+        message.getChatStyle().setColor(color);
+        toPlayer.addChatMessage(message);
     }
 }

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ICommandAction.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ICommandAction.java
@@ -1,0 +1,46 @@
+package xyz.uniblood.thaumicmixins.commands.actions;
+
+import net.minecraft.command.ICommandSender;
+
+import java.util.List;
+
+/**
+ * A sub-command or action that belongs to a command
+ */
+public interface ICommandAction
+{
+    /**
+     * The command-unique name of the action.
+     * @return The action's name.
+     */
+    String getName();
+
+    /**
+     * A lang key that explains how to use the action.
+     * @return The lang key.
+     */
+    String getUsage();
+
+    /**
+     * Execute the action.
+     * @param sender The command's executor.
+     * @param args The command's arguments.
+     */
+    void process(ICommandSender sender, String[] args);
+
+    /**
+     * Provide auto-completion for the action's arguments.
+     * @param sender The command's executor.
+     * @param args The command's arguments.
+     * @return A list of valid auto-completion values.
+     */
+    List<String> addTabCompletionOptions(ICommandSender sender, String[] args);
+
+    /**
+     * Whether the argument at the given index should be a username.
+     * @param args The command's arguments.
+     * @param index The index to check.
+     * @return True if the argument at the given index should be a username, false otherwise.
+     */
+    boolean isUsernameIndex(String[] args, int index);
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
@@ -7,8 +7,17 @@ import net.minecraftforge.common.config.Configuration;
 public class ThaumicMixinsConfig {
 
     //Category names
+    static final String categoryCommands = "commands";
     static final String categoryStructures = "structures";
     static final String categoryLoot = "loot";
+
+    // Commands
+    public static boolean enableCommand = true;
+    public static int commandPermissionLevel = 2;
+    public static boolean enableFindResearch = true;
+    public static boolean enableForgetResearch = true;
+    public static boolean enableForgetScanned = true;
+    public static boolean enableListResearch = true;
 
     // Structure
     public static boolean moundEnabled = true;
@@ -29,6 +38,13 @@ public class ThaumicMixinsConfig {
 
     public static void synchronizeConfiguration(File configFile) {
         Configuration configuration = new Configuration(configFile);
+
+        enableCommand = configuration.getBoolean("Enable Command", categoryCommands, enableCommand, "Enable the /tmixins command");
+        commandPermissionLevel = configuration.getInt("Command Required Permission Level", categoryCommands, commandPermissionLevel, 0, 4, "0 (all), 1 (moderator), 2 (gamemaster), 3 (admin), and 4 (owner)");
+        enableFindResearch = configuration.getBoolean("findResearch Enabled", categoryCommands, enableFindResearch, "Enable the 'findResearch' subcommand");
+        enableForgetResearch = configuration.getBoolean("forgetResearch Enabled", categoryCommands, enableForgetResearch, "Enable the 'forgetResearch' subcommand");
+        enableForgetScanned = configuration.getBoolean("forgetScanned Enabled", categoryCommands, enableForgetScanned, "Enable the 'forgetScanned' subcommand");
+        enableListResearch = configuration.getBoolean("listResearch Enabled", categoryCommands, enableListResearch, "Enable the 'listResearch' subcommand");
 
         // Structures
         moundEnabled = configuration.getBoolean("Mound Enabled", categoryStructures, moundEnabled, "");

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -1,0 +1,1 @@
+commands.tmixins.usage=If you're reading this, you are permitted to poke fun at rndmorris's forgetfulness until he fixes it

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -1,4 +1,4 @@
-commands.tmixins.usage=/tmixins <findResearchKey | forgetResearch | forgetScanned | listResearch> <arguments ...>
+commands.tmixins.usage=/tmixins <subCommand> <arguments ...>
 
 commands.tmixins.forgetresearch.usage=/tmixins forgetResearch <player> <research key | *> [refund sticky warp]
 commands.tmixins.forgetresearch.noresearch=Could not find research for key '%s'

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -1,9 +1,11 @@
 commands.tmixins.usage=/tmixins <forgetResearch | listResearch> <arguments ...>
 
-commands.tmixins.forgetresearch.usage=/tmixins forgetResearch <player> <research key> [refund sticky warp]
+commands.tmixins.forgetresearch.usage=/tmixins forgetResearch <player> <research key | *> [refund sticky warp]
 commands.tmixins.forgetresearch.noresearch=Could not find research for key '%s'
 commands.tmixins.forgetresearch.doesnotknow=%s has not completed '%s'
 commands.tmixins.forgetresearch.success=%s has forgotten about '%s'
 commands.tmixins.forgetresearch.notify=%s has made you forget about '%s' 
+commands.tmixins.forgetresearch.successall=%s has forgotten about everything
+commands.tmixins.forgetresearch.notifyall=%s has made you forget everything 
 
 commands.tmixins.listresearch.usage=/tmixins listResearch <player> [search text]

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -17,6 +17,6 @@ commands.tmixins.forgetscanned.notify=%s has made you forget your scanned %s
 commands.tmixins.forgetscanned.successall=%s has forgotten all %d things they've scanned
 commands.tmixins.forgetscanned.notifyall=%s has made you forget everything you've scanned
 
-commands.tmixins.findresearchkey.usage=/tmixins findResearchKey <search text...>
-commands.tmixins.findresearchkey.category=--- Category: %s ---
-commands.tmixins.findresearchkey.nonefound=No research found matching '%s'
+commands.tmixins.findresearch.usage=/tmixins findResearch <search text...>
+commands.tmixins.findresearch.category=--- Category: %s ---
+commands.tmixins.findresearch.nonefound=No research found matching '%s'

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -1,4 +1,4 @@
-commands.tmixins.usage=/tmixins <forgetResearch | listResearch> <arguments ...>
+commands.tmixins.usage=/tmixins <forgetResearch | forgetScanned | listResearch> <arguments ...>
 
 commands.tmixins.forgetresearch.usage=/tmixins forgetResearch <player> <research key | *> [refund sticky warp]
 commands.tmixins.forgetresearch.noresearch=Could not find research for key '%s'
@@ -8,4 +8,11 @@ commands.tmixins.forgetresearch.notify=%s has made you forget about '%s'
 commands.tmixins.forgetresearch.successall=%s has forgotten about everything
 commands.tmixins.forgetresearch.notifyall=%s has made you forget everything 
 
-commands.tmixins.listresearch.usage=/tmixins listResearch <player> [search text]
+commands.tmixins.listresearch.usage=/tmixins listResearch <player> [search text...]
+
+commands.tmixins.forgetscanned.usage=/tmixins forgetScanned <player> <objects | entities | nodes | *>
+commands.tmixins.forgetscanned.invalidtype=Unknown argument '%s'
+commands.tmixins.forgetscanned.success=%s has forgotten %d scanned %s
+commands.tmixins.forgetscanned.notify=%s has made you forget your scanned %s
+commands.tmixins.forgetscanned.successall=%s has forgotten all %d things they've scanned
+commands.tmixins.forgetscanned.notifyall=%s has made you forget everything you've scanned

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -1,1 +1,6 @@
-commands.tmixins.usage=If you're reading this, you are permitted to poke fun at rndmorris's forgetfulness until he fixes it
+commands.tmixins.usage=/tmixins <forgetResearch> <arguments ...>
+commands.tmixins.forgetresearch.usage=/tmixins forgetResearch <player> <research key> [refund sticky warp]
+commands.tmixins.forgetresearch.noresearch=Could not find research for key '%s'
+commands.tmixins.forgetresearch.doesnotknow=%s has not completed '%s'
+commands.tmixins.forgetresearch.success=%s has forgotten about '%s'
+commands.tmixins.forgetresearch.notify=%s has made you forget about '%s' 

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -1,6 +1,9 @@
-commands.tmixins.usage=/tmixins <forgetResearch> <arguments ...>
+commands.tmixins.usage=/tmixins <forgetResearch | listResearch> <arguments ...>
+
 commands.tmixins.forgetresearch.usage=/tmixins forgetResearch <player> <research key> [refund sticky warp]
 commands.tmixins.forgetresearch.noresearch=Could not find research for key '%s'
 commands.tmixins.forgetresearch.doesnotknow=%s has not completed '%s'
 commands.tmixins.forgetresearch.success=%s has forgotten about '%s'
 commands.tmixins.forgetresearch.notify=%s has made you forget about '%s' 
+
+commands.tmixins.listresearch.usage=/tmixins listResearch <player> [search text]

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -1,4 +1,4 @@
-commands.tmixins.usage=/tmixins <forgetResearch | forgetScanned | listResearch> <arguments ...>
+commands.tmixins.usage=/tmixins <findResearchKey | forgetResearch | forgetScanned | listResearch> <arguments ...>
 
 commands.tmixins.forgetresearch.usage=/tmixins forgetResearch <player> <research key | *> [refund sticky warp]
 commands.tmixins.forgetresearch.noresearch=Could not find research for key '%s'
@@ -16,3 +16,7 @@ commands.tmixins.forgetscanned.success=%s has forgotten %d scanned %s
 commands.tmixins.forgetscanned.notify=%s has made you forget your scanned %s
 commands.tmixins.forgetscanned.successall=%s has forgotten all %d things they've scanned
 commands.tmixins.forgetscanned.notifyall=%s has made you forget everything you've scanned
+
+commands.tmixins.findresearchkey.usage=/tmixins findResearchKey <search text...>
+commands.tmixins.findresearchkey.category=--- Category: %s ---
+commands.tmixins.findresearchkey.nonefound=No research found matching '%s'


### PR DESCRIPTION
This adds a `/tmixins` command with several sub-commands, useful for dev testing or server administration.

## Sub-commands
### findResearch
Usage: `/tmixins findResearch <search text...>`

| Argument | Description |
|:-:|:-|
| search text | Only results containing this text will be returned. The text can contain spaces. |

Filters through all research registered with Thaumcraft, returning any whose name or key contains the search text. For ease of searching, results are grouped by category.

### forgetResearch
Usage: `/tmixins forgetResearch <player> <research key | *> [refund sticky warp]`

| Argument | Description |
|:-:|:-|
| player | The player whose completed research will be modified |
| research key | The key of the root research to remove. Providing `*` instead will remove all of that player's research. Research registered as auto-unlocking is unaffected, though its children might be. |
| refund sticky warp | If true, an amount of sticky warp equal to that given by completing any forgotten research will be removed. |

Uncompletes some or all of the named player's completed research, allowing it to be completed again. If the research gave permanent warp, an equivalent amount is removed. If refund sticky warp is set, also removes an amount of sticky warp equal to that gained from the removed research.

### forgetScanned
Usage: `/tmixins forgetScanned <player> <objects | entities | nodes | *>`

| Argument | Description |
|:-:|:-|
| player | The player whose completed scans will be modified |
| objects \| entities \| nodes | Specifies the type of scan to reset. If `*` is provided, all will be reset. |

Clears the appropriate list of scanned things for the player, allowing them to be scanned again. Due to technical limitations (the list of scanned things involves hashes), this is all-or-nothing.

### listResearch
Usage: `/tmixins listResearch <player> [search text...]`

| Argument | Description |
|:-:|:-|
| player | The player whose completed research will be queried |
| search text | Only completed research whose key contains this text will be returned. The text can contain spaces. |

Returns the named player's list of completed research keys. Can optionally be filtered by search text.

## Configuration
This creates a new "commands" section in the config file.

### Enable Command (boolean)
Enables the `/tmixins` command. Default `true`.

### Command Required Permission Level (integer)
Sets the level of permission required to use the command. Accepts \[0, 4\]. default: 2.  Per [Minecraft.wiki](https://minecraft.wiki/w/Permission_level) (may be inaccurate for 1.7.10?)
| Level | Description |
|:-:|:-|
| 0 | all |
| 1 | moderator |
| 2 | gamemaster |
| 3 | admin |
| 4 | owner |

### findResearch Enabled (boolean)
Enables the findResearch sub-command. Default `true`.

### forgetResearch Enabled (boolean)
Enables the forgetResearch sub-command. Default `true`.

### forgetScanned Enabled (boolean)
Enables the forgetScanned sub-command. Default `true`.

### listResearch Enabled (boolean)
Enables the listResearch sub-command. Default `true`.