### PR TITLE
Node commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Usage: `/tmixins listResearch <player> [search text...]`
 
 Returns the named player's list of completed research keys. Can optionally be filtered by search text.
 
+### updateNode
+Usage: `/tmixins updateNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]] [-r <aspect1>[ -r <aspect2>[ ...]]]`
+
+|        Argument        | Description                                                                  |
+|:----------------------:|:-----------------------------------------------------------------------------|
+|     `<x> <y> <z>`      | Required. The coordinates of the node to update.                             |
+|    `-t <node_type>`    | Optional. Replace the node's type (hungry, pure, etc).                       |
+|  `-m <node_modifier>`  | Optional. Replace the node's modifier (bright, fading, pale, or none).       |
+| `-a <aspect> <amount>` | Optional. Set the node's capacity in the chosen aspect to the chosen amount. |
+|     `-r <aspect>`      | Optional. Remove the chosen aspect from the node.                            |
+
+Update an existing node at the specified coordinates.
+
 ### summonNode
 Usage: `/tmixins summonNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [--small] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]]`
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Usage: `/tmixins updateNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [-
 | `-a <aspect> <amount>` | Optional. Set the node's capacity in the chosen aspect to the chosen amount. |
 |     `-r <aspect>`      | Optional. Remove the chosen aspect from the node.                            |
 
-Update an existing node at the specified coordinates.
+Update an existing node at the specified coordinate.
 
 ### summonNode
 Usage: `/tmixins summonNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [--small] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]]`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Usage: `/tmixins listResearch <player> [search text...]`
 
 Returns the named player's list of completed research keys. Can optionally be filtered by search text.
 
+### summonNode
+Usage: `/tmixins summonNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [--small] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]]`
+
+|        Argument        | Description                                                                                                                                                                                                      |
+|:----------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|     `<x> <y> <z>`      | Required. The coordinates at which to create a new node.                                                                                                                                                         |
+|    `-t <node_type>`    | Optional. Specify the new node's type (hungry, pure, etc). If not set, node type will be random.                                                                                                                 |
+|  `-m <node_modifier>`  | Optional. Specify the new node's modifier (bright, fading, pale, or none). If not set, node modifier will be random.                                                                                             |
+|       `--small`        | Optional. If set, the node will generate with few aspects in low capacities. No effect if any aspects are specified by `-a`.                                                                                     |
+| `-a <aspect> <amount>` | Optional. Overrides `--small`. If set, the node will have the specified amount of the specified aspect. Can be set multiple times, adding a new aspect each time. If not set, the node's aspects will be random. |
+
+Summon a random node at the specified coordinates. The node's properties can be overridden by specifying additional optional arguments.
+
 # Credits
 
 * Unicorn Blood - Main Dev

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ Summon a random node at the specified coordinates. The node's properties can be 
 
 * Unicorn Blood - Main Dev
 * GTNH + jss2a98aj - Helping me with random bugs
-* rndmorris - tmixins command
+* rndmorris - `/tmixins` command, and `/thaumcraft` auto-complete

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -7,6 +7,7 @@ import xyz.uniblood.thaumicmixins.commands.actions.ActionFindResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetScanned;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionListResearch;
+import xyz.uniblood.thaumicmixins.commands.actions.ActionSummonNode;
 import xyz.uniblood.thaumicmixins.commands.actions.ICommandAction;
 import xyz.uniblood.thaumicmixins.config.ThaumicMixinsConfig;
 
@@ -33,6 +34,9 @@ public class CommandThaumicMixins extends CommandBase
         }
         if (ThaumicMixinsConfig.enableListResearch) {
             actions.add(new ActionListResearch());
+        }
+        if (ThaumicMixinsConfig.enableSummonNode) {
+            actions.add(new ActionSummonNode());
         }
         this.actions = actions.toArray(new ICommandAction[0]);
     }

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/CommandThaumicMixins.java
@@ -8,6 +8,7 @@ import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionForgetScanned;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionListResearch;
 import xyz.uniblood.thaumicmixins.commands.actions.ActionSummonNode;
+import xyz.uniblood.thaumicmixins.commands.actions.ActionUpdateNode;
 import xyz.uniblood.thaumicmixins.commands.actions.ICommandAction;
 import xyz.uniblood.thaumicmixins.config.ThaumicMixinsConfig;
 
@@ -34,6 +35,9 @@ public class CommandThaumicMixins extends CommandBase
         }
         if (ThaumicMixinsConfig.enableListResearch) {
             actions.add(new ActionListResearch());
+        }
+        if (ThaumicMixinsConfig.enableUpdateNode) {
+            actions.add(new ActionUpdateNode());
         }
         if (ThaumicMixinsConfig.enableSummonNode) {
             actions.add(new ActionSummonNode());

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
@@ -134,7 +134,7 @@ public class ActionSummonNode extends CommandAction
         }
 
         final var world = sender.getEntityWorld();
-        ThaumcraftWorldGenerator.createRandomNodeAt(world, x, y, z, world.rand, false, false, small);
+        ThaumcraftWorldGenerator.createRandomNodeAt(world, x, y, z, world.rand, type == NodeType.PURE, type == NodeType.DARK, small);
         final var tileEntity = world.getTileEntity(x, y, z);
         if (!(tileEntity instanceof TileNode node)) {
             ThaumicMixins.LOG.error("Could not find a TileNode at ({}, {}, {})", x, y, z);
@@ -143,7 +143,7 @@ public class ActionSummonNode extends CommandAction
         }
 
         var dirty = false;
-        if (type != null) {
+        if (type != null && type != NodeType.DARK && type != NodeType.PURE) {
             node.setNodeType(type);
             dirty = true;
         }

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
@@ -1,0 +1,162 @@
+package xyz.uniblood.thaumicmixins.commands.actions;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.nodes.NodeModifier;
+import thaumcraft.api.nodes.NodeType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ActionSummonNode extends CommandAction
+{
+    public static final String USAGE_KEY = "commands.tmixins.summonnode.usage";
+
+    private static final int ARG_INDEX_X = 1;
+    private static final int ARG_INDEX_Y = 2;
+    private static final int ARG_INDEX_Z = 3;
+
+    private static final String FLAG_TYPE = "-t";
+    private static final String FLAG_MODIFIER = "-m";
+    private static final String FLAG_SMALL = "--small";
+    private static final String FLAG_ASPECT = "-a";
+
+    private static final String MODIFIER_NONE = "NONE";
+
+    @Override
+    public String getName()
+    {
+        return "summonNode";
+    }
+
+    @Override
+    public String getUsage()
+    {
+        return "";
+    }
+
+    @Override
+    public void process(ICommandSender sender, String[] args)
+    {
+
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length <= ARG_INDEX_Z + 1) {
+            return null;
+        }
+
+        final var searchResults = searchArgs(args);
+        final var previousArgIndex = args.length - 2;
+
+        if (searchResults.typeIndex == previousArgIndex) {
+            return typeOptions(args);
+        }
+        if (searchResults.modifierIndex == previousArgIndex) {
+            return modifierOptions(args);
+        }
+        if (searchResults.lastAspectIndex == previousArgIndex) {
+            return aspectOptions(searchResults, args);
+        }
+        final var previousArg = args[previousArgIndex].toUpperCase();
+        if (searchResults.selectedAspects.contains(previousArg)) {
+            return null; // integer argument
+        }
+
+        return flagOptions(searchResults, args);
+    }
+
+    private static ArgsSearchResult searchArgs(String[] args) {
+        final var searchResults = new ArgsSearchResult();
+        for (var index = 1; index < args.length; ++index) {
+            final var arg = args[index];
+            final var argUpper = arg.toUpperCase();
+            if (FLAG_TYPE.equalsIgnoreCase(arg) && searchResults.typeIndex < 0) {
+                searchResults.typeIndex = index;
+            }
+            else if (FLAG_MODIFIER.equalsIgnoreCase(arg) && searchResults.modifierIndex < 0) {
+                searchResults.modifierIndex = index;
+            }
+            else if (FLAG_SMALL.equalsIgnoreCase(arg) && searchResults.smallIndex < 0) {
+                searchResults.smallIndex = index;
+            }
+            else if (FLAG_ASPECT.equalsIgnoreCase(arg)) {
+                searchResults.lastAspectIndex = index;
+            }
+            else if (searchResults.possibleAspects.contains(argUpper)) {
+                searchResults.selectedAspects.add(argUpper);
+            }
+        }
+        return searchResults;
+    }
+
+    private static class ArgsSearchResult
+    {
+        public int typeIndex = -1;
+        public int modifierIndex = -1;
+        public int smallIndex = -1;
+        public int lastAspectIndex = -1;
+
+        public final Set<String> selectedAspects = new HashSet<>();
+        public final Set<String> possibleAspects;
+
+        public ArgsSearchResult() {
+            this.possibleAspects = Aspect.aspects.keySet().stream().map(String::toUpperCase).collect(Collectors.toSet());
+        }
+
+        /**
+         * Get a set of all aspect keys that are not yet selected.
+         * @return a set of string
+         */
+        public Set<String> remainingAspects() {
+            final var result = new HashSet<>(possibleAspects);
+            result.removeAll(selectedAspects);
+            return result;
+        }
+    }
+
+    private List<String> flagOptions(ArgsSearchResult searchResult, String[] args) {
+        final var results = new ArrayList<String>(3);
+        if (searchResult.typeIndex < 0) {
+            results.add(FLAG_TYPE);
+        }
+        if (searchResult.modifierIndex < 0) {
+            results.add(FLAG_MODIFIER);
+        }
+        if (searchResult.smallIndex < 0) {
+            results.add(FLAG_SMALL);
+        }
+        if (searchResult.possibleAspects.size() > searchResult.selectedAspects.size()) {
+            results.add(FLAG_ASPECT);
+        }
+        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, results);
+    }
+
+    private List<String> typeOptions(String[] args) {
+        final var types = Arrays.stream(NodeType.values())
+            .map(NodeType::toString)
+            .toArray(String[]::new);
+        return CommandBase.getListOfStringsMatchingLastWord(args, types);
+    }
+
+    private List<String> modifierOptions(String[] args) {
+        final var options = new ArrayList<String>(4);
+        options.add(MODIFIER_NONE);
+        final var modifiers = Arrays.stream(NodeModifier.values())
+                .map(NodeModifier::toString)
+                .toArray(String[]::new);
+        Collections.addAll(options, modifiers);
+        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, options);
+    }
+
+    private List<String> aspectOptions(ArgsSearchResult searchResult, String[] args) {
+        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, searchResult.remainingAspects());
+    }
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
@@ -25,11 +25,11 @@ import java.util.stream.Collectors;
 public class ActionSummonNode extends CommandAction
 {
     private static final String USAGE_KEY = "commands.tmixins.summonnode.usage";
-    private static final String KEY_ERROR = "commands.tmixins.summonnode.error";
     private static final String KEY_INCOMPLETE = "commands.tmixins.summonnode.incomplete";
     private static final String KEY_MISSING = "commands.tmixins.summonnode.missing";
     private static final String KEY_MISSING_ASPECT = "commands.tmixins.summonnode.missingaspect";
     private static final String KEY_MISSING_MODIFIER = "commands.tmixins.summonnode.missingmodifier";
+    private static final String KEY_MISSING_NODE = "commands.tmixins.summonnode.missingnode";
     private static final String KEY_MISSING_TYPE = "commands.tmixins.summonnode.missingtype";
     private static final String KEY_SUCCESS = "commands.tmixins.summonnode.success";
 
@@ -66,7 +66,7 @@ public class ActionSummonNode extends CommandAction
         ModifierOptions modifier = null;
         NodeType type = null;
         boolean small = false;
-        final var coords = parseCoordinates(sender, args);
+        final var coords = parseCoordinates(sender, args[ARG_INDEX_X], args[ARG_INDEX_Y], args[ARG_INDEX_Z]);
         final int x = (int) coords.xCoord, y = (int) coords.yCoord, z = (int) coords.zCoord;
 
         if (searchResults.typeFlagIndex > -1) {
@@ -137,8 +137,7 @@ public class ActionSummonNode extends CommandAction
         ThaumcraftWorldGenerator.createRandomNodeAt(world, x, y, z, world.rand, type == NodeType.PURE, type == NodeType.DARK, small);
         final var tileEntity = world.getTileEntity(x, y, z);
         if (!(tileEntity instanceof TileNode node)) {
-            ThaumicMixins.LOG.error("Could not find a TileNode at ({}, {}, {})", x, y, z);
-            sendErrorMessage(sender, KEY_ERROR);
+            sendErrorMessage(sender, KEY_MISSING_NODE, x, y, z);
             return;
         }
 
@@ -185,51 +184,6 @@ public class ActionSummonNode extends CommandAction
             }
         }
         return searchResults;
-    }
-
-    private Vec3 parseCoordinates(ICommandSender sender, String[] args) {
-        final var playerCoords = sender.getPlayerCoordinates();
-        var x = playerCoords.posX;
-        var y = playerCoords.posY;
-        var z = playerCoords.posZ;
-        x = MathHelper.floor_double(CommandBase.func_110666_a(sender, x, args[ARG_INDEX_X]));
-        y = MathHelper.floor_double(CommandBase.func_110666_a(sender, y, args[ARG_INDEX_Y]));
-        z = MathHelper.floor_double(CommandBase.func_110666_a(sender, z, args[ARG_INDEX_Z]));
-        return Vec3.createVectorHelper(x, y, z);
-    }
-
-    private Integer tryParseInt(String[] args, int atIndex) {
-        if (atIndex >= args.length) {
-            return null;
-        }
-        try {
-            return Integer.parseInt(args[atIndex]);
-        } catch (NumberFormatException nfe) {
-            return null;
-        }
-    }
-
-    private <E extends Enum<E>> E tryParseEnum(Class<E> clazz, String arg) {
-        try {
-            return Enum.valueOf(clazz, arg);
-        }
-        catch (IllegalArgumentException iae) {
-            return null;
-        }
-    }
-
-    private Aspect parseAspect(String tag) {
-        var aspect = Aspect.getAspect(tag);
-        if (aspect != null) {
-            return aspect;
-        }
-        for (var iAspect : Aspect.aspects.values()) {
-            if (iAspect.getTag().equalsIgnoreCase(tag))
-            {
-                return iAspect;
-            }
-        }
-        return null;
     }
 
     @Override

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
@@ -142,14 +142,21 @@ public class ActionSummonNode extends CommandAction
             return;
         }
 
+        var dirty = false;
         if (type != null) {
             node.setNodeType(type);
+            dirty = true;
         }
         if (modifier != null) {
             node.setNodeModifier(modifier.toNodeModifier());
+            dirty = true;
         }
         if (aspects != null) {
             node.setAspects(aspects);
+            dirty = true;
+        }
+        if (dirty) {
+            node.markDirty();
         }
 
         sendSuccessMessage(sender, KEY_SUCCESS, x, y, z);

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
@@ -156,6 +156,7 @@ public class ActionSummonNode extends CommandAction
         }
         if (dirty) {
             node.markDirty();
+            world.markBlockForUpdate(x, y, z);
         }
 
         sendSuccessMessage(sender, KEY_SUCCESS, x, y, z);

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionSummonNode.java
@@ -2,21 +2,36 @@ package xyz.uniblood.thaumicmixins.commands.actions;
 
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.Vec3;
 import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.api.nodes.NodeType;
+import thaumcraft.common.lib.world.ThaumcraftWorldGenerator;
+import thaumcraft.common.tiles.TileNode;
+import xyz.uniblood.thaumicmixins.ThaumicMixins;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ActionSummonNode extends CommandAction
 {
-    public static final String USAGE_KEY = "commands.tmixins.summonnode.usage";
+    private static final String USAGE_KEY = "commands.tmixins.summonnode.usage";
+    private static final String KEY_ERROR = "commands.tmixins.summonnode.error";
+    private static final String KEY_INCOMPLETE = "commands.tmixins.summonnode.incomplete";
+    private static final String KEY_MISSING = "commands.tmixins.summonnode.missing";
+    private static final String KEY_MISSING_ASPECT = "commands.tmixins.summonnode.missingaspect";
+    private static final String KEY_MISSING_MODIFIER = "commands.tmixins.summonnode.missingmodifier";
+    private static final String KEY_MISSING_TYPE = "commands.tmixins.summonnode.missingtype";
+    private static final String KEY_SUCCESS = "commands.tmixins.summonnode.success";
 
     private static final int ARG_INDEX_X = 1;
     private static final int ARG_INDEX_Y = 2;
@@ -27,8 +42,6 @@ public class ActionSummonNode extends CommandAction
     private static final String FLAG_SMALL = "--small";
     private static final String FLAG_ASPECT = "-a";
 
-    private static final String MODIFIER_NONE = "NONE";
-
     @Override
     public String getName()
     {
@@ -38,31 +51,196 @@ public class ActionSummonNode extends CommandAction
     @Override
     public String getUsage()
     {
-        return "";
+        return USAGE_KEY;
     }
 
     @Override
     public void process(ICommandSender sender, String[] args)
     {
+        if (args.length < ARG_INDEX_Z + 1) {
+            throw new WrongUsageException(USAGE_KEY);
+        }
 
+        final var searchResults = searchArgs(args);
+        AspectList aspects = null;
+        ModifierOptions modifier = null;
+        NodeType type = null;
+        boolean small = false;
+        final var coords = parseCoordinates(sender, args);
+        final int x = (int) coords.xCoord, y = (int) coords.yCoord, z = (int) coords.zCoord;
+
+        if (searchResults.typeFlagIndex > -1) {
+            final var typeIndex = searchResults.typeFlagIndex + 1;
+            if (typeIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "node_type");
+                return;
+            }
+            final var typeString = args[typeIndex];
+            type = tryParseEnum(NodeType.class, typeString);
+            if (type == null) {
+                sendErrorMessage(sender, KEY_MISSING_TYPE, typeString);
+                return;
+            }
+        }
+
+        if (searchResults.modifierFlagIndex > -1) {
+            final var modifierIndex = searchResults.modifierFlagIndex + 1;
+            if (modifierIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "node_modifier");
+                return;
+            }
+            final var modifierString = args[modifierIndex];
+            modifier = tryParseEnum(ModifierOptions.class, modifierString);
+            if (modifier == null) {
+                sendErrorMessage(sender, KEY_MISSING_MODIFIER, modifierString);
+                return;
+            }
+        }
+
+        if (searchResults.smallFlagIndex > -1) {
+            small = true;
+        }
+
+        if (!searchResults.selectedAspects.isEmpty()) {
+            aspects = new AspectList();
+        }
+
+        for (var index = 0; index < searchResults.aspectFlagIndices.size(); ++index) {
+            final var aspectFlagNumber = index + 1;
+            final var aspectFlagIndex = searchResults.aspectFlagIndices.get(index);
+
+            final var aspectIndex = aspectFlagIndex + 1;
+            if (aspectIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "aspect" + aspectFlagNumber);
+                return;
+            }
+            final var aspect = parseAspect(args[aspectIndex]);
+            if (aspect == null) {
+                sendErrorMessage(sender, KEY_MISSING_ASPECT, args[aspectIndex]);
+                return;
+            }
+
+            final var amountIndex = aspectIndex + 1;
+            if (amountIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "amount" + aspectFlagNumber);
+                return;
+            }
+            final var amount = tryParseInt(args, amountIndex);
+            if (amount == null) {
+                sendErrorMessage(sender, KEY_MISSING, "amount" + aspectFlagNumber);
+                return;
+            }
+            Objects.requireNonNull(aspects).add(aspect, amount);
+        }
+
+        final var world = sender.getEntityWorld();
+        ThaumcraftWorldGenerator.createRandomNodeAt(world, x, y, z, world.rand, false, false, small);
+        final var tileEntity = world.getTileEntity(x, y, z);
+        if (!(tileEntity instanceof TileNode node)) {
+            ThaumicMixins.LOG.error("Could not find a TileNode at ({}, {}, {})", x, y, z);
+            sendErrorMessage(sender, KEY_ERROR);
+            return;
+        }
+
+        if (type != null) {
+            node.setNodeType(type);
+        }
+        if (modifier != null) {
+            node.setNodeModifier(modifier.toNodeModifier());
+        }
+        if (aspects != null) {
+            node.setAspects(aspects);
+        }
+
+        sendSuccessMessage(sender, KEY_SUCCESS, x, y, z);
+    }
+
+    private static ArgsSearchResult searchArgs(String[] args) {
+        final var searchResults = new ArgsSearchResult();
+        for (var index = 1; index < args.length; ++index) {
+            final var arg = args[index];
+            final var argUpper = arg.toUpperCase();
+            if (FLAG_TYPE.equalsIgnoreCase(arg) && searchResults.typeFlagIndex < 0) {
+                searchResults.typeFlagIndex = index;
+            }
+            else if (FLAG_MODIFIER.equalsIgnoreCase(arg) && searchResults.modifierFlagIndex < 0) {
+                searchResults.modifierFlagIndex = index;
+            }
+            else if (FLAG_SMALL.equalsIgnoreCase(arg) && searchResults.smallFlagIndex < 0) {
+                searchResults.smallFlagIndex = index;
+            }
+            else if (FLAG_ASPECT.equalsIgnoreCase(arg)) {
+                searchResults.aspectFlagIndices.add(index);
+                searchResults.lastAspectFlagIndex = index;
+            }
+            else if (searchResults.possibleAspects.contains(argUpper) && FLAG_ASPECT.equalsIgnoreCase(args[index - 1])) {
+                searchResults.selectedAspects.add(argUpper);
+            }
+        }
+        return searchResults;
+    }
+
+    private Vec3 parseCoordinates(ICommandSender sender, String[] args) {
+        final var playerCoords = sender.getPlayerCoordinates();
+        var x = playerCoords.posX;
+        var y = playerCoords.posY;
+        var z = playerCoords.posZ;
+        x = MathHelper.floor_double(CommandBase.func_110666_a(sender, x, args[ARG_INDEX_X]));
+        y = MathHelper.floor_double(CommandBase.func_110666_a(sender, y, args[ARG_INDEX_Y]));
+        z = MathHelper.floor_double(CommandBase.func_110666_a(sender, z, args[ARG_INDEX_Z]));
+        return Vec3.createVectorHelper(x, y, z);
+    }
+
+    private Integer tryParseInt(String[] args, int atIndex) {
+        if (atIndex >= args.length) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(args[atIndex]);
+        } catch (NumberFormatException nfe) {
+            return null;
+        }
+    }
+
+    private <E extends Enum<E>> E tryParseEnum(Class<E> clazz, String arg) {
+        try {
+            return Enum.valueOf(clazz, arg);
+        }
+        catch (IllegalArgumentException iae) {
+            return null;
+        }
+    }
+
+    private Aspect parseAspect(String tag) {
+        var aspect = Aspect.getAspect(tag);
+        if (aspect != null) {
+            return aspect;
+        }
+        for (var iAspect : Aspect.aspects.values()) {
+            if (iAspect.getTag().equalsIgnoreCase(tag))
+            {
+                return iAspect;
+            }
+        }
+        return null;
     }
 
     @Override
     public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
-        if (args.length <= ARG_INDEX_Z + 1) {
-            return null;
+        if (args.length > 1 && args.length <= 4) {
+            return Collections.singletonList("~");
         }
 
         final var searchResults = searchArgs(args);
         final var previousArgIndex = args.length - 2;
 
-        if (searchResults.typeIndex == previousArgIndex) {
+        if (searchResults.typeFlagIndex == previousArgIndex) {
             return typeOptions(args);
         }
-        if (searchResults.modifierIndex == previousArgIndex) {
+        if (searchResults.modifierFlagIndex == previousArgIndex) {
             return modifierOptions(args);
         }
-        if (searchResults.lastAspectIndex == previousArgIndex) {
+        if (searchResults.lastAspectFlagIndex == previousArgIndex) {
             return aspectOptions(searchResults, args);
         }
         final var previousArg = args[previousArgIndex].toUpperCase();
@@ -73,37 +251,48 @@ public class ActionSummonNode extends CommandAction
         return flagOptions(searchResults, args);
     }
 
-    private static ArgsSearchResult searchArgs(String[] args) {
-        final var searchResults = new ArgsSearchResult();
-        for (var index = 1; index < args.length; ++index) {
-            final var arg = args[index];
-            final var argUpper = arg.toUpperCase();
-            if (FLAG_TYPE.equalsIgnoreCase(arg) && searchResults.typeIndex < 0) {
-                searchResults.typeIndex = index;
-            }
-            else if (FLAG_MODIFIER.equalsIgnoreCase(arg) && searchResults.modifierIndex < 0) {
-                searchResults.modifierIndex = index;
-            }
-            else if (FLAG_SMALL.equalsIgnoreCase(arg) && searchResults.smallIndex < 0) {
-                searchResults.smallIndex = index;
-            }
-            else if (FLAG_ASPECT.equalsIgnoreCase(arg)) {
-                searchResults.lastAspectIndex = index;
-            }
-            else if (searchResults.possibleAspects.contains(argUpper)) {
-                searchResults.selectedAspects.add(argUpper);
-            }
+    private List<String> flagOptions(ArgsSearchResult searchResult, String[] args) {
+        final var results = new ArrayList<String>(3);
+        if (searchResult.typeFlagIndex < 0) {
+            results.add(FLAG_TYPE);
         }
-        return searchResults;
+        if (searchResult.modifierFlagIndex < 0) {
+            results.add(FLAG_MODIFIER);
+        }
+        if (searchResult.smallFlagIndex < 0) {
+            results.add(FLAG_SMALL);
+        }
+        if (searchResult.possibleAspects.size() > searchResult.selectedAspects.size()) {
+            results.add(FLAG_ASPECT);
+        }
+        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, results);
     }
 
-    private static class ArgsSearchResult
-    {
-        public int typeIndex = -1;
-        public int modifierIndex = -1;
-        public int smallIndex = -1;
-        public int lastAspectIndex = -1;
+    private List<String> typeOptions(String[] args) {
+        final var types = Arrays.stream(NodeType.values())
+            .map(NodeType::toString)
+            .toArray(String[]::new);
+        return CommandBase.getListOfStringsMatchingLastWord(args, types);
+    }
 
+    private List<String> modifierOptions(String[] args) {
+        final var modifiers = Arrays.stream(ModifierOptions.values())
+                .map(ModifierOptions::toString)
+                .toArray(String[]::new);
+        return CommandBase.getListOfStringsMatchingLastWord(args, modifiers);
+    }
+
+    private List<String> aspectOptions(ArgsSearchResult searchResult, String[] args) {
+        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, searchResult.remainingAspects());
+    }
+
+    private static class ArgsSearchResult {
+        public int typeFlagIndex = -1;
+        public int modifierFlagIndex = -1;
+        public int smallFlagIndex = -1;
+        public int lastAspectFlagIndex = -1;
+
+        public final List<Integer> aspectFlagIndices = new ArrayList<>();
         public final Set<String> selectedAspects = new HashSet<>();
         public final Set<String> possibleAspects;
 
@@ -122,41 +311,19 @@ public class ActionSummonNode extends CommandAction
         }
     }
 
-    private List<String> flagOptions(ArgsSearchResult searchResult, String[] args) {
-        final var results = new ArrayList<String>(3);
-        if (searchResult.typeIndex < 0) {
-            results.add(FLAG_TYPE);
-        }
-        if (searchResult.modifierIndex < 0) {
-            results.add(FLAG_MODIFIER);
-        }
-        if (searchResult.smallIndex < 0) {
-            results.add(FLAG_SMALL);
-        }
-        if (searchResult.possibleAspects.size() > searchResult.selectedAspects.size()) {
-            results.add(FLAG_ASPECT);
-        }
-        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, results);
-    }
+    private enum ModifierOptions {
+        NONE,
+        BRIGHT,
+        PALE,
+        FADING;
 
-    private List<String> typeOptions(String[] args) {
-        final var types = Arrays.stream(NodeType.values())
-            .map(NodeType::toString)
-            .toArray(String[]::new);
-        return CommandBase.getListOfStringsMatchingLastWord(args, types);
-    }
-
-    private List<String> modifierOptions(String[] args) {
-        final var options = new ArrayList<String>(4);
-        options.add(MODIFIER_NONE);
-        final var modifiers = Arrays.stream(NodeModifier.values())
-                .map(NodeModifier::toString)
-                .toArray(String[]::new);
-        Collections.addAll(options, modifiers);
-        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, options);
-    }
-
-    private List<String> aspectOptions(ArgsSearchResult searchResult, String[] args) {
-        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, searchResult.remainingAspects());
+        public NodeModifier toNodeModifier() {
+            return switch (this) {
+                case NONE -> null;
+                case BRIGHT -> NodeModifier.BRIGHT;
+                case PALE -> NodeModifier.PALE;
+                case FADING -> NodeModifier.FADING;
+            };
+        }
     }
 }

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionUpdateNode.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionUpdateNode.java
@@ -177,7 +177,10 @@ public class ActionUpdateNode extends CommandAction
         if (addAspects != null) {
             for (var aspect : addAspects.getAspects()) {
                 nodeAspects.remove(aspect);
-                nodeAspects.add(aspect, addAspects.getAmount(aspect));
+                final var addAmount = addAspects.getAmount(aspect);
+                if (addAmount > 0) {
+                    nodeAspects.add(aspect, addAspects.getAmount(aspect));
+                }
             }
             aspectsDirty = true;
         }

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionUpdateNode.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/ActionUpdateNode.java
@@ -1,0 +1,321 @@
+package xyz.uniblood.thaumicmixins.commands.actions;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.nodes.NodeModifier;
+import thaumcraft.api.nodes.NodeType;
+import thaumcraft.common.tiles.TileNode;
+import xyz.uniblood.thaumicmixins.ThaumicMixins;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ActionUpdateNode extends CommandAction
+{
+    private static final String USAGE_KEY = "commands.tmixins.updatenode.usage";
+    private static final String KEY_INCOMPLETE = "commands.tmixins.updatenode.incomplete";
+    private static final String KEY_MISSING = "commands.tmixins.updatenode.missing";
+    private static final String KEY_MISSING_ASPECT = "commands.tmixins.updatenode.missingaspect";
+    private static final String KEY_MISSING_MODIFIER = "commands.tmixins.updatenode.missingmodifier";
+    private static final String KEY_MISSING_NODE = "commands.tmixins.updatenode.missingnode";
+    private static final String KEY_MISSING_TYPE = "commands.tmixins.updatenode.missingtype";
+    private static final String KEY_SUCCESS = "commands.tmixins.updatenode.success";
+
+    private static final int ARG_INDEX_X = 1;
+    private static final int ARG_INDEX_Y = 2;
+    private static final int ARG_INDEX_Z = 3;
+
+    private static final String FLAG_TYPE = "-t";
+    private static final String FLAG_MODIFIER = "-m";
+    private static final String FLAG_ADD_ASPECT = "-a";
+    private static final String FLAG_REMOVE_ASPECT = "-r";
+
+    @Override
+    public String getName()
+    {
+        return "updateNode";
+    }
+
+    @Override
+    public String getUsage()
+    {
+        return USAGE_KEY;
+    }
+
+    @Override
+    public void process(ICommandSender sender, String[] args)
+    {
+        if (args.length < ARG_INDEX_Z + 1) {
+            throw new WrongUsageException(USAGE_KEY);
+        }
+
+        final var searchResults = searchArgs(args);
+        AspectList addAspects = null;
+        Collection<Aspect> removeAspects = null;
+        ModifierOptions modifier = null;
+        NodeType type = null;
+        final var coords = parseCoordinates(sender, args[ARG_INDEX_X], args[ARG_INDEX_Y], args[ARG_INDEX_Z]);
+        final int x = (int) coords.xCoord, y = (int) coords.yCoord, z = (int) coords.zCoord;
+
+        if (searchResults.typeFlagIndex > -1) {
+            final var typeIndex = searchResults.typeFlagIndex + 1;
+            if (typeIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "node_type");
+                return;
+            }
+            final var typeString = args[typeIndex];
+            type = tryParseEnum(NodeType.class, typeString);
+            if (type == null) {
+                sendErrorMessage(sender, KEY_MISSING_TYPE, typeString);
+                return;
+            }
+        }
+
+        if (searchResults.modifierFlagIndex > -1) {
+            final var modifierIndex = searchResults.modifierFlagIndex + 1;
+            if (modifierIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "node_modifier");
+                return;
+            }
+            final var modifierString = args[modifierIndex];
+            modifier = tryParseEnum(ModifierOptions.class, modifierString);
+            if (modifier == null) {
+                sendErrorMessage(sender, KEY_MISSING_MODIFIER, modifierString);
+                return;
+            }
+        }
+
+        // Aspects to add or adjust in the node
+        if (!searchResults.addAspectFlagIndices.isEmpty()) {
+            addAspects = new AspectList();
+        }
+        for (var index = 0; index < searchResults.addAspectFlagIndices.size(); ++index) {
+            final var aspectFlagNumber = index + 1;
+            final var aspectFlagIndex = searchResults.addAspectFlagIndices.get(index);
+
+            final var aspectIndex = aspectFlagIndex + 1;
+            if (aspectIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "aspect" + aspectFlagNumber);
+                return;
+            }
+            final var aspect = parseAspect(args[aspectIndex]);
+            if (aspect == null) {
+                sendErrorMessage(sender, KEY_MISSING_ASPECT, args[aspectIndex]);
+                return;
+            }
+
+            final var amountIndex = aspectIndex + 1;
+            if (amountIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "amount" + aspectFlagNumber);
+                return;
+            }
+            final var amount = tryParseInt(args, amountIndex);
+            if (amount == null) {
+                sendErrorMessage(sender, KEY_MISSING, "amount" + aspectFlagNumber);
+                return;
+            }
+            Objects.requireNonNull(addAspects).add(aspect, amount);
+        }
+
+        // Aspects to remove from the node
+        if (!searchResults.removeAspectFlagIndices.isEmpty()) {
+            removeAspects = new LinkedList<>();
+        }
+        for (var index = 0; index < searchResults.removeAspectFlagIndices.size(); ++index) {
+            final var aspectFlagNumber = index + 1;
+            final var aspectFlagIndex = searchResults.removeAspectFlagIndices.get(index);
+
+            final var aspectIndex = aspectFlagIndex + 1;
+            if (aspectIndex >= args.length) {
+                sendErrorMessage(sender, KEY_INCOMPLETE, "aspect" + aspectFlagNumber);
+                return;
+            }
+            final var aspect = parseAspect(args[aspectIndex]);
+            if (aspect == null) {
+                sendErrorMessage(sender, KEY_MISSING_ASPECT, args[aspectIndex]);
+                return;
+            }
+
+            Objects.requireNonNull(removeAspects).add(aspect);
+        }
+
+        final var world = sender.getEntityWorld();
+        final var tileEntity = world.getTileEntity(x, y, z);
+        if (!(tileEntity instanceof TileNode node)) {
+            sendErrorMessage(sender, KEY_MISSING_NODE, x, y, z);
+            return;
+        }
+
+        var dirty = false;
+        var aspectsDirty = false;
+        if (type != null) {
+            node.setNodeType(type);
+            dirty = true;
+        }
+        if (modifier != null) {
+            node.setNodeModifier(modifier.toNodeModifier());
+            dirty = true;
+        }
+        final var nodeAspects = node.getAspectsBase();
+        if (removeAspects != null) {
+            for (var aspect : removeAspects) {
+                nodeAspects.remove(aspect);
+            }
+            aspectsDirty = true;
+        }
+        if (addAspects != null) {
+            for (var aspect : addAspects.getAspects()) {
+                nodeAspects.remove(aspect);
+                nodeAspects.add(aspect, addAspects.getAmount(aspect));
+            }
+            aspectsDirty = true;
+        }
+        if (aspectsDirty) {
+            node.setAspects(nodeAspects);
+            dirty = true;
+        }
+        if (dirty) {
+            node.markDirty();
+            world.markBlockForUpdate(x, y, z);
+        }
+
+        sendSuccessMessage(sender, KEY_SUCCESS, x, y, z);
+    }
+
+    private static ArgsSearchResult searchArgs(String[] args) {
+        final var searchResults = new ArgsSearchResult();
+        for (var index = 1; index < args.length; ++index) {
+            final var arg = args[index];
+            final var argUpper = arg.toUpperCase();
+            if (FLAG_TYPE.equalsIgnoreCase(arg) && searchResults.typeFlagIndex < 0) {
+                searchResults.typeFlagIndex = index;
+            }
+            else if (FLAG_MODIFIER.equalsIgnoreCase(arg) && searchResults.modifierFlagIndex < 0) {
+                searchResults.modifierFlagIndex = index;
+            }
+            else if (FLAG_ADD_ASPECT.equalsIgnoreCase(arg)) {
+                searchResults.addAspectFlagIndices.add(index);
+                searchResults.lastAspectFlagIndex = index;
+            }
+            else if (FLAG_REMOVE_ASPECT.equalsIgnoreCase(arg)) {
+                searchResults.removeAspectFlagIndices.add(index);
+                searchResults.lastAspectFlagIndex = index;
+            }
+            else if (searchResults.possibleAspects.contains(argUpper) && FLAG_ADD_ASPECT.equalsIgnoreCase(args[index - 1])) {
+                searchResults.selectedAspects.add(argUpper);
+            }
+        }
+        return searchResults;
+    }
+
+    @Override
+    public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if (args.length > 1 && args.length <= 4) {
+            return Collections.singletonList("~");
+        }
+
+        final var searchResults = searchArgs(args);
+        final var previousArgIndex = args.length - 2;
+
+        if (searchResults.typeFlagIndex == previousArgIndex) {
+            return typeOptions(args);
+        }
+        if (searchResults.modifierFlagIndex == previousArgIndex) {
+            return modifierOptions(args);
+        }
+        if (searchResults.lastAspectFlagIndex == previousArgIndex) {
+            return aspectOptions(searchResults, args);
+        }
+        final var previousArg = args[previousArgIndex].toUpperCase();
+        if (searchResults.selectedAspects.contains(previousArg) && args[previousArgIndex - 1].equalsIgnoreCase(FLAG_ADD_ASPECT)) {
+            return null; // integer argument
+        }
+
+        return flagOptions(searchResults, args);
+    }
+
+    private List<String> flagOptions(ArgsSearchResult searchResult, String[] args) {
+        final var results = new ArrayList<String>(3);
+        if (searchResult.typeFlagIndex < 0) {
+            results.add(FLAG_TYPE);
+        }
+        if (searchResult.modifierFlagIndex < 0) {
+            results.add(FLAG_MODIFIER);
+        }
+        if (searchResult.possibleAspects.size() > searchResult.selectedAspects.size()) {
+            results.add(FLAG_ADD_ASPECT);
+            results.add(FLAG_REMOVE_ASPECT);
+        }
+        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, results);
+    }
+
+    private List<String> typeOptions(String[] args) {
+        final var types = Arrays.stream(NodeType.values())
+            .map(NodeType::toString)
+            .toArray(String[]::new);
+        return CommandBase.getListOfStringsMatchingLastWord(args, types);
+    }
+
+    private List<String> modifierOptions(String[] args) {
+        final var modifiers = Arrays.stream(ModifierOptions.values())
+                .map(ModifierOptions::toString)
+                .toArray(String[]::new);
+        return CommandBase.getListOfStringsMatchingLastWord(args, modifiers);
+    }
+
+    private List<String> aspectOptions(ArgsSearchResult searchResult, String[] args) {
+        return CommandBase.getListOfStringsFromIterableMatchingLastWord(args, searchResult.remainingAspects());
+    }
+
+    private static class ArgsSearchResult {
+        public int typeFlagIndex = -1;
+        public int modifierFlagIndex = -1;
+        public int lastAspectFlagIndex = -1;
+
+        public final List<Integer> addAspectFlagIndices = new ArrayList<>();
+        public final List<Integer> removeAspectFlagIndices = new ArrayList<>();
+        public final Set<String> selectedAspects = new HashSet<>();
+        public final Set<String> possibleAspects;
+
+        public ArgsSearchResult() {
+            this.possibleAspects = Aspect.aspects.keySet().stream().map(String::toUpperCase).collect(Collectors.toSet());
+        }
+
+        /**
+         * Get a set of all aspect keys that are not yet selected.
+         * @return a set of string
+         */
+        public Set<String> remainingAspects() {
+            final var result = new HashSet<>(possibleAspects);
+            result.removeAll(selectedAspects);
+            return result;
+        }
+    }
+
+    private enum ModifierOptions {
+        NONE,
+        BRIGHT,
+        PALE,
+        FADING;
+
+        public NodeModifier toNodeModifier() {
+            return switch (this) {
+                case NONE -> null;
+                case BRIGHT -> NodeModifier.BRIGHT;
+                case PALE -> NodeModifier.PALE;
+                case FADING -> NodeModifier.FADING;
+            };
+        }
+    }
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/CommandAction.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/commands/actions/CommandAction.java
@@ -1,8 +1,12 @@
 package xyz.uniblood.thaumicmixins.commands.actions;
 
+import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.Vec3;
+import thaumcraft.api.aspects.Aspect;
 
 import java.util.Collections;
 import java.util.List;
@@ -33,5 +37,50 @@ public abstract class CommandAction implements ICommandAction
         final var message = new ChatComponentTranslation(translationKey, args);
         message.getChatStyle().setColor(color);
         toPlayer.addChatMessage(message);
+    }
+
+    protected static Vec3 parseCoordinates(ICommandSender sender, String xStr, String yStr, String zStr) {
+        final var playerCoords = sender.getPlayerCoordinates();
+        var x = playerCoords.posX;
+        var y = playerCoords.posY;
+        var z = playerCoords.posZ;
+        x = MathHelper.floor_double(CommandBase.func_110666_a(sender, x, xStr));
+        y = MathHelper.floor_double(CommandBase.func_110666_a(sender, y, yStr));
+        z = MathHelper.floor_double(CommandBase.func_110666_a(sender, z, zStr));
+        return Vec3.createVectorHelper(x, y, z);
+    }
+
+    protected static Integer tryParseInt(String[] args, int atIndex) {
+        if (atIndex >= args.length) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(args[atIndex]);
+        } catch (NumberFormatException nfe) {
+            return null;
+        }
+    }
+
+    protected static Aspect parseAspect(String tag) {
+        var aspect = Aspect.getAspect(tag);
+        if (aspect != null) {
+            return aspect;
+        }
+        for (var iAspect : Aspect.aspects.values()) {
+            if (iAspect.getTag().equalsIgnoreCase(tag))
+            {
+                return iAspect;
+            }
+        }
+        return null;
+    }
+
+    protected static <E extends Enum<E>> E tryParseEnum(Class<E> clazz, String arg) {
+        try {
+            return Enum.valueOf(clazz, arg);
+        }
+        catch (IllegalArgumentException iae) {
+            return null;
+        }
     }
 }

--- a/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
@@ -18,6 +18,7 @@ public class ThaumicMixinsConfig {
     public static boolean enableForgetResearch = true;
     public static boolean enableForgetScanned = true;
     public static boolean enableListResearch = true;
+    public static boolean enableUpdateNode = true;
     public static boolean enableSummonNode = true;
 
     // Structure
@@ -46,6 +47,7 @@ public class ThaumicMixinsConfig {
         enableForgetResearch = configuration.getBoolean("forgetResearch Enabled", categoryCommands, enableForgetResearch, "Enable the 'forgetResearch' subcommand");
         enableForgetScanned = configuration.getBoolean("forgetScanned Enabled", categoryCommands, enableForgetScanned, "Enable the 'forgetScanned' subcommand");
         enableListResearch = configuration.getBoolean("listResearch Enabled", categoryCommands, enableListResearch, "Enable the 'listResearch' subcommand");
+        enableUpdateNode = configuration.getBoolean("updateNode Enabled", categoryCommands, enableUpdateNode, "Enable the 'updateNode' subcommand");
         enableSummonNode = configuration.getBoolean("summonNode Enabled", categoryCommands, enableSummonNode, "Enable the 'summonNode' subcommand");
 
         // Structures

--- a/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
@@ -18,6 +18,7 @@ public class ThaumicMixinsConfig {
     public static boolean enableForgetResearch = true;
     public static boolean enableForgetScanned = true;
     public static boolean enableListResearch = true;
+    public static boolean enableSummonNode = true;
 
     // Structure
     public static boolean moundEnabled = true;
@@ -45,6 +46,7 @@ public class ThaumicMixinsConfig {
         enableForgetResearch = configuration.getBoolean("forgetResearch Enabled", categoryCommands, enableForgetResearch, "Enable the 'forgetResearch' subcommand");
         enableForgetScanned = configuration.getBoolean("forgetScanned Enabled", categoryCommands, enableForgetScanned, "Enable the 'forgetScanned' subcommand");
         enableListResearch = configuration.getBoolean("listResearch Enabled", categoryCommands, enableListResearch, "Enable the 'listResearch' subcommand");
+        enableSummonNode = configuration.getBoolean("summonNode Enabled", categoryCommands, enableSummonNode, "Enable the 'summonNode' subcommand");
 
         // Structures
         moundEnabled = configuration.getBoolean("Mound Enabled", categoryStructures, moundEnabled, "");

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -22,4 +22,10 @@ commands.tmixins.findresearch.category=--- Category: %s ---
 commands.tmixins.findresearch.nonefound=No research found matching '%s'
 
 commands.tmixins.summonnode.usage=/tmixins summonNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [--small] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]]
-commands.tmixins.summonnode.success=Summoned a %s %s node at %d %d %d
+commands.tmixins.summonnode.success=Summoned a node at %d %d %d
+commands.tmixins.summonnode.error=Something went wrong
+commands.tmixins.summonnode.incomplete=Incomplete argument '%s'
+commands.tmixins.summonnode.missing=Missing argument '%s'
+commands.tmixins.summonnode.missingaspect=Unknown aspect '%s'
+commands.tmixins.summonnode.missingmodifier=Unknown node modifier '%s'
+commands.tmixins.summonnode.missingtype=Unknown node type '%s'

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -20,3 +20,6 @@ commands.tmixins.forgetscanned.notifyall=%s has made you forget everything you'v
 commands.tmixins.findresearch.usage=/tmixins findResearch <search text...>
 commands.tmixins.findresearch.category=--- Category: %s ---
 commands.tmixins.findresearch.nonefound=No research found matching '%s'
+
+commands.tmixins.summonnode.usage=/tmixins summonNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [--small] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]]
+commands.tmixins.summonnode.success=Summoned a %s %s node at %d %d %d

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -23,9 +23,9 @@ commands.tmixins.findresearch.nonefound=No research found matching '%s'
 
 commands.tmixins.summonnode.usage=/tmixins summonNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [--small] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]]
 commands.tmixins.summonnode.success=Summoned a node at %d %d %d
-commands.tmixins.summonnode.error=Something went wrong
 commands.tmixins.summonnode.incomplete=Incomplete argument '%s'
 commands.tmixins.summonnode.missing=Missing argument '%s'
 commands.tmixins.summonnode.missingaspect=Unknown aspect '%s'
 commands.tmixins.summonnode.missingmodifier=Unknown node modifier '%s'
+commands.tmixins.summonnode.missingnode=No node found at (%d, %d, %d).
 commands.tmixins.summonnode.missingtype=Unknown node type '%s'

--- a/src/main/resources/assets/thaumicmixins/lang/en_US.lang
+++ b/src/main/resources/assets/thaumicmixins/lang/en_US.lang
@@ -29,3 +29,12 @@ commands.tmixins.summonnode.missingaspect=Unknown aspect '%s'
 commands.tmixins.summonnode.missingmodifier=Unknown node modifier '%s'
 commands.tmixins.summonnode.missingnode=No node found at (%d, %d, %d).
 commands.tmixins.summonnode.missingtype=Unknown node type '%s'
+
+commands.tmixins.updatenode.usage=/tmixins updateNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]] [-r <aspect1>[ -r <aspect2>[ ...]]]
+commands.tmixins.updatenode.success=Updated a node at %d %d %d
+commands.tmixins.updatenode.incomplete=Incomplete argument '%s'
+commands.tmixins.updatenode.missing=Missing argument '%s'
+commands.tmixins.updatenode.missingaspect=Unknown aspect '%s'
+commands.tmixins.updatenode.missingmodifier=Unknown node modifier '%s'
+commands.tmixins.updatenode.missingnode=No node found at (%d, %d, %d).
+commands.tmixins.updatenode.missingtype=Unknown node type '%s'


### PR DESCRIPTION
Adds a command action to summon a new node

## Configuration Changes

`commands."updateNode Enabled"` Enables or disables the new updateNode action.
`commands."summonNode Enabled"` Enables or disables the new summonNode action.


## Features

### updateNode
Usage: `/tmixins updateNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]] [-r <aspect1>[ -r <aspect2>[ ...]]]`

|        Argument        | Description                                                                  |
|:----------------------:|:-----------------------------------------------------------------------------|
|     `<x> <y> <z>`      | Required. The coordinates of the node to update.                             |
|    `-t <node_type>`    | Optional. Replace the node's type (hungry, pure, etc).                       |
|  `-m <node_modifier>`  | Optional. Replace the node's modifier (bright, fading, pale, or none).       |
| `-a <aspect> <amount>` | Optional. Set the node's capacity in the chosen aspect to the chosen amount. |
|     `-r <aspect>`      | Optional. Remove the chosen aspect from the node.                            |

Update an existing node at the specified coordinates.

### summonNode
Usage: `/tmixins summonNode <x> <y> <z> [-t <node_type>] [-m <node_modifier>] [--small] [-a <aspect1> <amount1>[ -a <aspect2> <amount2>[ ...]]]`

|        Argument        | Description                                                                                                                                                                                                      |
|:----------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
|     `<x> <y> <z>`      | Required. The coordinates at which to create a new node.                                                                                                                                                         |
|    `-t <node_type>`    | Optional. Specify the new node's type (hungry, pure, etc). If not set, node type will be random.                                                                                                                 |
|  `-m <node_modifier>`  | Optional. Specify the new node's modifier (bright, fading, pale, or none). If not set, node modifier will be random.                                                                                             |
|       `--small`        | Optional. If set, the node will generate with few aspects in low capacities. No effect if any aspects are specified by `-a`.                                                                                     |
| `-a <aspect> <amount>` | Optional. Overrides `--small`. If set, the node will have the specified amount of the specified aspect. Can be set multiple times, adding a new aspect each time. If not set, the node's aspects will be random. |

Summon a random node at the specified coordinates. The node's properties can be overridden by specifying additional optional arguments.