### PR TITLE
Restrict BlockCosmeticSolid's beacon base metadata values

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A mod to add more configuration to Thaumcraft 4. Possibly bugfixes as well.
 * Auto-completion support for the `/thaumcraft` command
 * Whitelist config for adding more possible champion mobs
 * Blacklist config to remove champion mobs added by other mods
+
+# Bugfixes
 * Restrict BlockCosmeticSolid so only Thaumium Blocks register as a beacon base
 
 # Planned Features

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A mod to add more configuration to Thaumcraft 4. Possibly bugfixes as well.
 * Auto-completion support for the `/thaumcraft` command
 * Whitelist config for adding more possible champion mobs
 * Blacklist config to remove champion mobs added by other mods
+* Config for which BlockCosmeticSolid metadata values are beacon base blocks
 
 # Planned Features
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A mod to add more configuration to Thaumcraft 4. Possibly bugfixes as well.
 * Auto-completion support for the `/thaumcraft` command
 * Whitelist config for adding more possible champion mobs
 * Blacklist config to remove champion mobs added by other mods
-* Config for which BlockCosmeticSolid metadata values are beacon base blocks
+* Restrict BlockCosmeticSolid so only Thaumium Blocks register as a beacon base
 
 # Planned Features
 

--- a/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
@@ -7,14 +7,13 @@ import net.minecraftforge.common.config.Configuration;
 public class ThaumicMixinsConfig {
 
     //Category names
-    static final String categoryBlocks = "blocks";
     static final String categoryCommands = "commands";
     static final String categoryStructures = "structures";
     static final String categoryLoot = "loot";
     static final String categoryEntities = "entities";
 
     // Blocks
-    public static int[] blockCosmeticSolidBeaconMetadataValues = new int[] { 4 };
+    public static int thaumiumBlockMetadata = 4;
 
     // Commands
     public static boolean enableCommand = true;
@@ -65,9 +64,6 @@ public class ThaumicMixinsConfig {
 
     public static void synchronizeConfiguration(File configFile) {
         Configuration configuration = new Configuration(configFile);
-
-        // Blocks
-        blockCosmeticSolidBeaconMetadataValues = configuration.get(categoryBlocks, "blockCosmeticSolidBeaconMetadata", blockCosmeticSolidBeaconMetadataValues, "Which metadata values for BlockCosmeticSolid are valid beacon base blocks.").getIntList();
 
         // Commands
         enableCommand = configuration.getBoolean("Enable Command", categoryCommands, enableCommand, "Enable the /tmixins command");

--- a/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
@@ -14,7 +14,7 @@ public class ThaumicMixinsConfig {
     static final String categoryEntities = "entities";
 
     // Blocks
-    public static int[] blockCosmeticSolidBeaconMetadatas = new int[] { 4 };
+    public static int[] blockCosmeticSolidBeaconMetadataValues = new int[] { 4 };
 
     // Commands
     public static boolean enableCommand = true;
@@ -67,7 +67,7 @@ public class ThaumicMixinsConfig {
         Configuration configuration = new Configuration(configFile);
 
         // Blocks
-        blockCosmeticSolidBeaconMetadatas = configuration.get(categoryBlocks, "blockCosmeticSolidBeaconMetadatas", blockCosmeticSolidBeaconMetadatas, "Which metadata values for BlockCosmeticSolid are valid beacon base blocks.").getIntList();
+        blockCosmeticSolidBeaconMetadataValues = configuration.get(categoryBlocks, "blockCosmeticSolidBeaconMetadata", blockCosmeticSolidBeaconMetadataValues, "Which metadata values for BlockCosmeticSolid are valid beacon base blocks.").getIntList();
 
         // Commands
         enableCommand = configuration.getBoolean("Enable Command", categoryCommands, enableCommand, "Enable the /tmixins command");

--- a/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
@@ -7,10 +7,14 @@ import net.minecraftforge.common.config.Configuration;
 public class ThaumicMixinsConfig {
 
     //Category names
+    static final String categoryBlocks = "blocks";
     static final String categoryCommands = "commands";
     static final String categoryStructures = "structures";
     static final String categoryLoot = "loot";
     static final String categoryEntities = "entities";
+
+    // Blocks
+    public static int[] blockCosmeticSolidBeaconMetadatas = new int[] { 4 };
 
     // Commands
     public static boolean enableCommand = true;
@@ -62,6 +66,10 @@ public class ThaumicMixinsConfig {
     public static void synchronizeConfiguration(File configFile) {
         Configuration configuration = new Configuration(configFile);
 
+        // Blocks
+        blockCosmeticSolidBeaconMetadatas = configuration.get(categoryBlocks, "blockCosmeticSolidBeaconMetadatas", blockCosmeticSolidBeaconMetadatas, "Which metadata values for BlockCosmeticSolid are valid beacon base blocks.").getIntList();
+
+        // Commands
         enableCommand = configuration.getBoolean("Enable Command", categoryCommands, enableCommand, "Enable the /tmixins command");
         commandPermissionLevel = configuration.getInt("Command Required Permission Level", categoryCommands, commandPermissionLevel, 0, 4, "0 (all), 1 (moderator), 2 (gamemaster), 3 (admin), and 4 (owner)");
         enableFindResearch = configuration.getBoolean("findResearch Enabled", categoryCommands, enableFindResearch, "Enable the 'findResearch' subcommand");

--- a/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/config/ThaumicMixinsConfig.java
@@ -7,6 +7,7 @@ import net.minecraftforge.common.config.Configuration;
 public class ThaumicMixinsConfig {
 
     //Category names
+    static final String categoryBugfixes = "bugfixes";
     static final String categoryCommands = "commands";
     static final String categoryStructures = "structures";
     static final String categoryLoot = "loot";
@@ -14,6 +15,9 @@ public class ThaumicMixinsConfig {
 
     // Blocks
     public static int thaumiumBlockMetadata = 4;
+
+    // Bugfixes
+    public static boolean enableCosmeticSolidBeaconFix = true;
 
     // Commands
     public static boolean enableCommand = true;
@@ -64,6 +68,9 @@ public class ThaumicMixinsConfig {
 
     public static void synchronizeConfiguration(File configFile) {
         Configuration configuration = new Configuration(configFile);
+
+        // Bugfixes
+        enableCosmeticSolidBeaconFix = configuration.getBoolean("Enable BlockCosmeticSolid Beacon Fix", categoryBugfixes, enableCosmeticSolidBeaconFix, "Restrict BlockCosmeticSolid so only Thaumium Blocks are registered as beacon base blocks. Disable to resume normal behavior (i.e. allowing Tallow Blocks and Arcane Stone Blocks, among others, to register as beacon base blocks).");
 
         // Commands
         enableCommand = configuration.getBoolean("Enable Command", categoryCommands, enableCommand, "Enable the /tmixins command");

--- a/src/main/java/xyz/uniblood/thaumicmixins/mixinplugin/ThaumicMixinsLateMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/mixinplugin/ThaumicMixinsLateMixins.java
@@ -22,6 +22,7 @@ public class ThaumicMixinsLateMixins implements ILateMixinLoader {
         mixins.add("MixinWorldGenMound");
         mixins.add("MixinEventHandlerEntity");
         mixins.add("MixinThaumcraftCommand");
+        mixins.add("MixinBlockCosmeticSolid");
         return mixins;
     }
 }

--- a/src/main/java/xyz/uniblood/thaumicmixins/mixinplugin/ThaumicMixinsLateMixins.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/mixinplugin/ThaumicMixinsLateMixins.java
@@ -3,6 +3,7 @@ package xyz.uniblood.thaumicmixins.mixinplugin;
 
 import com.gtnewhorizon.gtnhmixins.ILateMixinLoader;
 import com.gtnewhorizon.gtnhmixins.LateMixin;
+import xyz.uniblood.thaumicmixins.config.ThaumicMixinsConfig;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/xyz/uniblood/thaumicmixins/mixins/late/MixinBlockCosmeticSolid.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/mixins/late/MixinBlockCosmeticSolid.java
@@ -1,0 +1,38 @@
+package xyz.uniblood.thaumicmixins.mixins.late;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.world.IBlockAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import thaumcraft.common.blocks.BlockCosmeticSolid;
+import xyz.uniblood.thaumicmixins.config.ThaumicMixinsConfig;
+
+@Mixin(value = BlockCosmeticSolid.class, remap = false)
+public abstract class MixinBlockCosmeticSolid extends Block {
+
+    protected MixinBlockCosmeticSolid(Material materialIn) {
+        super(materialIn);
+    }
+
+    @Inject(method = "isBeaconBase", at = @At("HEAD"), cancellable = true)
+    public void onIsBeaconBase(IBlockAccess worldObj, int x, int y, int z, int beaconX, int beaconY, int beaconZ, CallbackInfoReturnable<Boolean> cir) {
+        final var returnValue = worldObj.getBlock(x, y, z) == this && thaumic_Mixins$isConfigMetadata(worldObj.getBlockMetadata(x, y, z));
+        cir.setReturnValue(returnValue);
+        cir.cancel();
+    }
+
+    @Unique
+    private boolean thaumic_Mixins$isConfigMetadata(int metadata) {
+        for (var configMetadata : ThaumicMixinsConfig.blockCosmeticSolidBeaconMetadatas) {
+            if (metadata == configMetadata) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/xyz/uniblood/thaumicmixins/mixins/late/MixinBlockCosmeticSolid.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/mixins/late/MixinBlockCosmeticSolid.java
@@ -19,6 +19,10 @@ public abstract class MixinBlockCosmeticSolid extends Block {
 
     @Inject(method = "isBeaconBase", at = @At("HEAD"), cancellable = true)
     public void onIsBeaconBase(IBlockAccess worldObj, int x, int y, int z, int beaconX, int beaconY, int beaconZ, CallbackInfoReturnable<Boolean> cir) {
+        // Mixins are loaded before the config is read, so here is the next best place to use this
+        if (!ThaumicMixinsConfig.enableCosmeticSolidBeaconFix) {
+            return;
+        }
         final var returnValue = worldObj.getBlock(x, y, z) == this && worldObj.getBlockMetadata(x, y, z) == ThaumicMixinsConfig.thaumiumBlockMetadata;
         cir.setReturnValue(returnValue);
         cir.cancel();

--- a/src/main/java/xyz/uniblood/thaumicmixins/mixins/late/MixinBlockCosmeticSolid.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/mixins/late/MixinBlockCosmeticSolid.java
@@ -4,7 +4,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.world.IBlockAccess;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -20,19 +19,8 @@ public abstract class MixinBlockCosmeticSolid extends Block {
 
     @Inject(method = "isBeaconBase", at = @At("HEAD"), cancellable = true)
     public void onIsBeaconBase(IBlockAccess worldObj, int x, int y, int z, int beaconX, int beaconY, int beaconZ, CallbackInfoReturnable<Boolean> cir) {
-        final var returnValue = worldObj.getBlock(x, y, z) == this && thaumic_Mixins$isConfigMetadata(worldObj.getBlockMetadata(x, y, z));
+        final var returnValue = worldObj.getBlock(x, y, z) == this && worldObj.getBlockMetadata(x, y, z) == ThaumicMixinsConfig.thaumiumBlockMetadata;
         cir.setReturnValue(returnValue);
         cir.cancel();
     }
-
-    @Unique
-    private boolean thaumic_Mixins$isConfigMetadata(int metadata) {
-        for (var configMetadata : ThaumicMixinsConfig.blockCosmeticSolidBeaconMetadataValues) {
-            if (metadata == configMetadata) {
-                return true;
-            }
-        }
-        return false;
-    }
-
 }

--- a/src/main/java/xyz/uniblood/thaumicmixins/mixins/late/MixinBlockCosmeticSolid.java
+++ b/src/main/java/xyz/uniblood/thaumicmixins/mixins/late/MixinBlockCosmeticSolid.java
@@ -27,7 +27,7 @@ public abstract class MixinBlockCosmeticSolid extends Block {
 
     @Unique
     private boolean thaumic_Mixins$isConfigMetadata(int metadata) {
-        for (var configMetadata : ThaumicMixinsConfig.blockCosmeticSolidBeaconMetadatas) {
+        for (var configMetadata : ThaumicMixinsConfig.blockCosmeticSolidBeaconMetadataValues) {
             if (metadata == configMetadata) {
                 return true;
             }


### PR DESCRIPTION
This PR restricts BlockCosmeticSolid so only Thaumium Blocks count as beacon base blocks.

# Before
![0 before](https://github.com/user-attachments/assets/273ba149-3dd2-4b0b-b589-bbb5f8a3e576)

# After
![1 after](https://github.com/user-attachments/assets/3843a3d0-2ea3-4e29-ac20-61f7c8fde654)
